### PR TITLE
Add missing target_link_libraries in the CMake build system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,7 @@ target_link_libraries(mgmol-opt ${HDF5_HL_LIBRARIES})
 target_link_libraries(mgmol-opt ${BLAS_LIBRARIES})
 target_link_libraries(mgmol-opt ${LAPACK_LIBRARIES})
 target_link_libraries(mgmol-opt ${Boost_LIBRARIES})
+target_link_libraries(mgmol-opt ${MPI_CXX_LIBRARIES})
 
 install(TARGETS mgmol-opt DESTINATION bin)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,24 +178,35 @@ target_include_directories(testAndersonMix PRIVATE
                            ${CMAKE_SOURCE_DIR}/tests/Anderson
                            ${HDF5_INCLUDE_DIRS})
 
-target_link_libraries(testHDF5P ${HDF5_LIBRARIES})
+target_link_libraries(testHDF5P ${HDF5_LIBRARIES}
+                                ${MPI_CXX_LIBRARIES})
+target_link_libraries(testMPI ${MPI_CXX_LIBRARIES})
 target_link_libraries(testBlacsContext ${SCALAPACK_LIBRARIES}
-                                       ${BLAS_LIBRARIES})
+                                       ${BLAS_LIBRARIES}
+                                       ${MPI_CXX_LIBRARIES})
 target_link_libraries(testDistVector ${SCALAPACK_LIBRARIES}
-                                     ${BLAS_LIBRARIES})
+                                     ${BLAS_LIBRARIES}
+                                     ${MPI_CXX_LIBRARIES})
 target_link_libraries(testDistMatrix ${SCALAPACK_LIBRARIES}
-                                     ${BLAS_LIBRARIES})
+                                     ${BLAS_LIBRARIES}
+                                     ${MPI_CXX_LIBRARIES})
 target_link_libraries(testConditionDistMatrix ${SCALAPACK_LIBRARIES}
-                                              ${BLAS_LIBRARIES})
+                                              ${BLAS_LIBRARIES}
+                                              ${MPI_CXX_LIBRARIES})
 target_link_libraries(testConditionDistMatrixPower ${SCALAPACK_LIBRARIES}
-                                              ${BLAS_LIBRARIES})
+                                              ${BLAS_LIBRARIES}
+                                              ${MPI_CXX_LIBRARIES})
 target_link_libraries(testPower ${BLAS_LIBRARIES}
-                                ${SCALAPACK_LIBRARIES})
+                                ${SCALAPACK_LIBRARIES}
+                                ${MPI_CXX_LIBRARIES})
 target_link_libraries(testPowerDistMatrix ${BLAS_LIBRARIES}
-                                ${SCALAPACK_LIBRARIES})
+                                ${SCALAPACK_LIBRARIES}
+                                ${MPI_CXX_LIBRARIES})
+target_link_libraries(testDirectionalReduce ${MPI_CXX_LIBRARIES})
 target_link_libraries(testAndersonMix ${LAPACK_LIBRARIES}
                                       ${BLAS_LIBRARIES}
-                                      ${Boost_LIBRARIES})
+                                      ${Boost_LIBRARIES}
+                                      ${MPI_CXX_LIBRARIES})
 
 set_tests_properties(testSiH4 PROPERTIES REQUIRED_FILES
                      ${CMAKE_SOURCE_DIR}/potentials/pseudo.Si)


### PR DESCRIPTION
I have a linking error about missing MPI symbols without this change. I think the reason it currently works it's because you set `CMAKE_CXX_COMPILER=mpiCC` and I don't. This is not advised see https://github.com/dealii/dealii/issues/5510#issuecomment-349761025