### PR TITLE
Clang format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,19 @@ if(${MGMOL_WITH_TRICUBIC} OR DEFINED TRICUBIC_ROOT)
   endif(${TRICUBIC_FOUND})
 endif(${MGMOL_WITH_TRICUBIC} OR DEFINED TRICUBIC_ROOT)
 
+# clang-format (optional)
+set(MGMOL_WITH_CLANG_FORMAT FALSE CACHE BOOL "Indent code with clang-format")
+if(${MGMOL_WITH_CLANG_FORMAT})
+  find_package(CLANG_FORMAT)
+  if(${CLANG_FORMAT_FOUND})
+    message(STATUS "Indent with clang-format")
+    file(GLOB_RECURSE FORMAT_SOURCES src/*.cc src/*.h tests/*.cc tests/*.h)
+    add_custom_target(format
+      COMMAND ${CLANG_FORMAT_EXECUTABLE} -i -style=file ${FORMAT_SOURCES}
+      DEPENDS ${FORMAT_SOURCES})
+  endif(${CLANG_FORMAT_FOUND})
+endif()
+
 enable_testing()
 
 # additional definitions

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
       gcc \
       gfortran \
       build-essential \
+      clang-format \
       wget \
       curl \
       bison \

--- a/ci/compile_and_run.sh
+++ b/ci/compile_and_run.sh
@@ -4,10 +4,12 @@ cd $1
 rm -rf build
 mkdir build && cd build
 ARGS=(
-  -D SCALAPACK_LIBRARY=/usr/lib/x86_64-linux-gnu/libscalapack-openmpi.so.2.0
+  -D SCALAPACK_ROOT=/usr/lib/x86_64-linux-gnu
+  -D MGMOL_WITH_CLANG_FORMAT=ON
   )
 cmake "${ARGS[@]}" ../
 make -j8
 ctest --no-compress-output -T Test
+make format && git diff --exit-code
 
 exit 0

--- a/cmake_modules/FindCLANG_FORMAT.cmake
+++ b/cmake_modules/FindCLANG_FORMAT.cmake
@@ -1,0 +1,31 @@
+# Find clang-format
+#
+# CLANG_FORMAT_EXECUTABLE   - Path to clang-format executable
+# CLANG_FORMAT_FOUND        - True if clang-format executable was found
+# CLANG_FORMAT_VERSION      - The version of clang-format found
+
+find_program(CLANG_FORMAT_EXECUTABLE
+  NAMES clang-format clang-format-6.0
+  DOC "clang-format executable")
+mark_as_advanced(CLANG_FORMAT_EXECUTABLE)
+
+# Extract version
+if (CLANG_FORMAT_EXECUTABLE)
+  execute_process(COMMAND ${CLANG_FORMAT_EXECUTABLE} -version
+    OUTPUT_VARIABLE clang_format_version
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if (clang_format_version MATCHES "^clang-format version .*")
+    # clang_format_version sample: "clang-format version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)"
+    string(REGEX REPLACE "clang-format version ([.0-9]+).*" "\\1" 
+      CLANG_FORMAT_VERSION "${clang_format_version}")
+  endif()
+  if (NOT CLANG_FORMAT_VERSION STREQUAL "6.0.0" AND
+      NOT CLANG_FORMAT_VERSION STREQUAL "6.0.1")
+    message(SEND_ERROR "Wrong clang-format version. Please use clang-format 6.0.")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set CLANG_FORMAT_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(CLANG_FORMAT REQUIRED_VARS CLANG_FORMAT_EXECUTABLE VERSION_VAR CLANG_FORMAT_VERSION)


### PR DESCRIPTION
This adds a new command `make format` that reformat the code. There is also a new test that checks that the code is formatted correctly. I have used cllang-format 6.0 but just let me know if you prefer another version.

~This is not ready to be merged. I want to make sure that the test will fail.~
This is ready to be merged. Let me know if you think that the last commit should be it's own PR.