### PR TITLE
Template MGgemm on the MemorySpaceType

### DIFF
--- a/src/linear_algebra/mputils.h
+++ b/src/linear_algebra/mputils.h
@@ -15,6 +15,17 @@
 #include "blas2_c.h"
 #include "blas3_c.h"
 
+namespace MemorySpace
+{
+struct Host
+{
+};
+
+struct Device
+{
+};
+}
+
 /* scal */
 /* scalar times vector for use in templates.
  * Calls blas dscal or sscal depending on arguments
@@ -112,21 +123,15 @@ void Tgemv(const char trans, const int m, const int n, const float alpha,
     const float* const a, const int lda, const float* const x, const int incx,
     const float beta, float* const y, const int incy);
 
-/* Mixed precision gemm */
-void MPgemm(const char transa, const char transb, const int m, const int n,
-    const int k, const double alpha, const double* const a, const int lda,
-    const double* const b, const int ldb, const double beta, double* const c,
-    const int ldc);
-void MPgemm(const char transa, const char transb, const int m, const int n,
-    const int k, const double alpha, const float* const a, const int lda,
-    const float* const b, const int ldb, const double beta, float* const c,
-    const int ldc);
-
-template <typename T1, typename T2, typename T3>
-void MPgemm(const char transa, const char transb, const int m, const int n,
-    const int k, const double alpha, const T1* const a, const int lda,
-    const T2* const b, const int ldb, const double beta, T3* const c,
-    const int ldc);
+template <typename MemorySpaceType>
+struct LinearAlgebraUtils
+{
+    template <typename T1, typename T2, typename T3>
+    static void MPgemm(const char transa, const char transb, const int m,
+        const int n, const int k, const double alpha, const T1* const a,
+        const int lda, const T2* const b, const int ldb, const double beta,
+        T3* const c, const int ldc);
+};
 
 void MPgemmNN(const int m, const int n, const int k, const double alpha,
     const float* const a, const int lda, const double* const b, const int ldb,

--- a/src/local_matrices/LocalMatrices.cc
+++ b/src/local_matrices/LocalMatrices.cc
@@ -170,7 +170,8 @@ void LocalMatrices<T>::gemm(const int iloc, const int ma, const double* const a,
     T* const c = ptr_matrices_[iloc];
     assert(c != 0);
 
-    MPgemm('t', 'n', m_, n_, ma, 1., a, lda, b, ldb, 0., c, m_);
+    LinearAlgebraUtils<MemorySpace::Host>::MPgemm(
+        't', 'n', m_, n_, ma, 1., a, lda, b, ldb, 0., c, m_);
 }
 
 template <class T>
@@ -185,7 +186,8 @@ void LocalMatrices<T>::gemm(const int iloc, const int ma, const float* const a,
     T* const c = ptr_matrices_[iloc];
     assert(c != 0);
 
-    MPgemm('t', 'n', m_, n_, ma, 1., a, lda, b, ldb, 0., c, m_);
+    LinearAlgebraUtils<MemorySpace::Host>::MPgemm(
+        't', 'n', m_, n_, ma, 1., a, lda, b, ldb, 0., c, m_);
 }
 
 // matrix multiplication
@@ -212,8 +214,8 @@ void LocalMatrices<T>::gemm(const char transa, const char transb,
         assert(c != 0);
 
         // do matrix multiplication
-        MPgemm(transa, transb, m_, n_, nca, alpha, amat, lda, bmat, ldb, beta,
-            c, m_);
+        LinearAlgebraUtils<MemorySpace::Host>::MPgemm(transa, transb, m_, n_,
+            nca, alpha, amat, lda, bmat, ldb, beta, c, m_);
     }
 }
 


### PR DESCRIPTION
This is what I had in mind. If you look at the header file, I think it is pretty clean. You can see in `LocalMatrices.cc` how the function will be used. The changes in `mputils.cc` are hard to read because I moved the code around but basically here is the idea:
```C++
template <typename MemorySpaceType>
template <typename T1, type T2, type T3>
void LAU<MemorySpaceType>::MPgemm<T1,T2,T3>(...)
{
 // This should never be called
}

template <>
template <typename T1, type T2, type T3>
void LAU<MemorySpace::Host>::MPgemm<T1,T2,T3>(...)
{
  // Specialization for the host space
}

template <>
template <>
void LAU<MemorySpace::Host>::MPgemm<float, float, float>(...)
{
  // Specialization for the host space and for the input type
}
```