### PR TITLE
Fix a memory leak

### DIFF
--- a/src/GrassmanCG.cc
+++ b/src/GrassmanCG.cc
@@ -27,9 +27,9 @@ void GrassmanCG<T>::conjugate()
     // compute conjugation
     T* new_pcgrad = GrassmanLineMinimization<T>::new_pcgrad_;
     T* new_grad   = GrassmanLineMinimization<T>::new_grad_;
-    T* grad       = GrassmanLineMinimization<T>::grad_;
-    T* pcgrad     = GrassmanLineMinimization<T>::pcgrad_;
-    T* sdir       = GrassmanLineMinimization<T>::sdir_;
+    T*& grad      = GrassmanLineMinimization<T>::grad_;
+    T*& pcgrad    = GrassmanLineMinimization<T>::pcgrad_;
+    T*& sdir      = GrassmanLineMinimization<T>::sdir_;
     if (GrassmanLineMinimization<T>::conjugate_)
     {
         // Numerator: compute matG = (MG^T*(G-G_old)) = MG^T*G - MG^T*G_old


### PR DESCRIPTION
The local variables are used in a new [here](https://github.com/LLNL/mgmol/compare/release...Rombur:memory_leak?expand=1#diff-e3c343076c84cb8f0107e02ceb119d44R71-R73). Since the pointer are copied, only the local variables will get a new address. See [here]( https://wandbox.org/permlink/e6H54p34lxk1Piv8).