### PR TITLE
Remove USE_MPI macro since MPI is always required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,11 +87,6 @@ list(APPEND LINK_LIBRARIES ${MGMOL_LINK_FLAGS})
 
 # Use MPI (required)
 find_package(MPI REQUIRED)
-if (${MPI_CXX_FOUND})
-  add_definitions(-DUSE_MPI)
-else(${MPI_CXX_FOUND})
-  message(FATAL_ERROR "Required MPI package not found. Please specify correct path to MPI.")  
-endif (${MPI_CXX_FOUND})
 message(STATUS "MPIEXEC :" ${MPIEXEC})
 # Use openMP if available
 find_package(OpenMP)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,10 +152,6 @@ if(${MGMOL_WITH_MAGMA})
   target_link_libraries(mgmol_src PkgConfig::MAGMA)
 endif()
 
-# compile definitions
-#target_compile_definitions (mgmol_src PUBLIC -DUSE_CNR_)
-target_compile_definitions (mgmol_src PUBLIC -DUSE_MPI)
-
 install(TARGETS mgmol_src DESTINATION lib)
 
 # build executable

--- a/src/ConstraintSet.cc
+++ b/src/ConstraintSet.cc
@@ -61,10 +61,8 @@ bool ConstraintSet::addConstraint(Ions& ions, const vector<string>& argv)
                 char_buf + shift, argv[i].c_str(), sizeof(char) * (len[i] + 1));
             shift += len[i] + 1;
         }
-#ifdef USE_MPI
     mmpi.bcast(&len[0], argc);
     mmpi.bcast(char_buf, size_buf);
-#endif
     shift = 0;
     vector<char*> largv(argc);
     for (int i = 0; i < argc; i++)

--- a/src/Control.h
+++ b/src/Control.h
@@ -20,9 +20,7 @@
 #include <string>
 #include <vector>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 class Potentials;
 

--- a/src/DistMatrix/BlacsContext.cc
+++ b/src/DistMatrix/BlacsContext.cc
@@ -105,7 +105,6 @@ namespace dist_matrix
 ////////////////////////////////////////////////////////////////////////////////
 void BlacsContext::buildCommunicator()
 {
-#if USE_MPI
     int* ranks = new int[size_];
     for (int i = 0; i < size_; i++)
         ranks[i] = i;
@@ -130,10 +129,6 @@ void BlacsContext::buildCommunicator()
     }
     MPI_Comm_create(comm_global_, subgroup, &comm_active_);
     delete[] ranks;
-
-#else
-    comm_active_ = 0;
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -144,13 +139,8 @@ BlacsContext::BlacsContext(MPI_Comm comm_global)
 
     // construct a single row global context
     char order = 'R';
-#if USE_MPI
     MPI_Comm_size(comm_global, &nprocs_);
     MPI_Comm_rank(comm_global, &mype_);
-#else
-    nprocs_      = 1;
-    mype_        = 0;
-#endif
 
     size_  = nprocs_;
     nprow_ = 1;
@@ -176,13 +166,8 @@ BlacsContext::BlacsContext(
     // largest square if type == 's'
 
     char order = 'R';
-#if USE_MPI
     MPI_Comm_size(comm_global, &nprocs_);
     MPI_Comm_rank(comm_global, &mype_);
-#else
-    nprocs_      = 1;
-    mype_        = 0;
-#endif
 
     size_ = std::min(nprocs_, max_cpus);
 
@@ -234,13 +219,8 @@ BlacsContext::BlacsContext(
       comm_global_(comm_global)
 {
     char order = 'R';
-#if USE_MPI
     MPI_Comm_size(comm_global_, &nprocs_);
     MPI_Comm_rank(comm_global_, &mype_);
-#else
-    nprocs_      = 1;
-    mype_        = 0;
-#endif
     if (nprocs_ < nprow * npcol)
     {
         std::cerr << " nprocs_=" << nprocs_ << std::endl;
@@ -268,13 +248,8 @@ BlacsContext::BlacsContext(
       npcol_(npcol),
       comm_global_(comm_global)
 {
-#if USE_MPI
     MPI_Comm_size(comm_global, &nprocs_);
     MPI_Comm_rank(comm_global, &mype_);
-#else
-    nprocs_      = 1;
-    mype_        = 0;
-#endif
 
     if (ipe < 0 || nprow <= 0 || npcol <= 0 || ipe + nprow * npcol > nprocs_)
     {
@@ -295,7 +270,6 @@ BlacsContext::BlacsContext(
     size_ = nprow_ * npcol_;
 
     // build MPI communicator for this context
-#if USE_MPI
     int* ranks = new int[size_];
     for (int i = 0; i < size_; i++)
         ranks[i] = ipe + i;
@@ -304,9 +278,6 @@ BlacsContext::BlacsContext(
     MPI_Group_incl(group_world, size_, ranks, &subgroup);
     MPI_Comm_create(comm_global, subgroup, &comm_active_);
     delete[] ranks;
-#else
-    comm_active_ = 0;
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -343,14 +314,10 @@ BlacsContext::BlacsContext(BlacsContext& bc, const int irow, const int icol,
     setup();
     size_ = nprow_ * npcol_;
 
-#if USE_MPI
     MPI_Group bc_group, subgroup;
     MPI_Comm_group(bc.comm_active(), &bc_group);
     MPI_Group_incl(bc_group, size_, pmap, &subgroup);
     MPI_Comm_create(bc.comm_active(), subgroup, &comm_active_);
-#else
-    comm_active_ = 0;
-#endif
     delete[] pmap;
 }
 
@@ -395,14 +362,10 @@ BlacsContext::BlacsContext(const BlacsContext& bc, const char type)
     setup();
     size_ = nprow_ * npcol_;
 
-#if USE_MPI
     MPI_Group bc_group, subgroup;
     MPI_Comm_group(bc.comm_active(), &bc_group);
     MPI_Group_incl(bc_group, size_, pmap, &subgroup);
     MPI_Comm_create(bc.comm_active(), subgroup, &comm_active_);
-#else
-    comm_        = 0;
-#endif
     delete[] pmap;
 }
 

--- a/src/DistMatrix/BlacsContext.h
+++ b/src/DistMatrix/BlacsContext.h
@@ -11,11 +11,7 @@
 #ifndef MGMOL_BLACSCONTEXT_H
 #define MGMOL_BLACSCONTEXT_H
 
-#if USE_MPI
 #include <mpi.h>
-#else
-typedef int MPI_Comm;
-#endif
 
 namespace dist_matrix
 {

--- a/src/DistMatrix/DistMatrix.cc
+++ b/src/DistMatrix/DistMatrix.cc
@@ -21,9 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #ifdef SCALAPACK
 #include "blacs.h"
@@ -1376,9 +1374,7 @@ double DistMatrix<double>::norm(char ty)
         norm_val = dlange(&ty, &m_, &n_, &val_[0], &m_, &work[0]);
 #endif
     }
-#ifdef USE_MPI
     MPI_Bcast(&norm_val, 1, MPI_DOUBLE, 0, comm_global_);
-#endif
     return norm_val;
 }
 
@@ -1404,9 +1400,7 @@ double DistMatrix<float>::norm(char ty)
         norm_val     = (double)slange(&ty, &m_, &n_, &val_[0], &m_, &work[0]);
 #endif
     }
-#ifdef USE_MPI
     MPI_Bcast(&norm_val, 1, MPI_FLOAT, 0, comm_global_);
-#endif
     return norm_val;
 }
 
@@ -2051,7 +2045,6 @@ void DistMatrix<T>::getDiagonalValues(T* const dmat) const
             }
         }
     }
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     T* recvbuf      = new T[m_];
     mmpi.allreduce(dmat, recvbuf, m_, MPI_SUM);
@@ -2059,7 +2052,6 @@ void DistMatrix<T>::getDiagonalValues(T* const dmat) const
     //                   MPI_DOUBLE, MPI_SUM, comm_global_ );
     memcpy(dmat, recvbuf, m_ * sizeof(T));
     delete[] recvbuf;
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2083,9 +2075,7 @@ double DistMatrix<double>::trace(void) const
 #endif
     }
 
-#ifdef USE_MPI
     MPI_Bcast(&trace, 1, MPI_DOUBLE, 0, comm_global_);
-#endif
     return trace;
 }
 
@@ -2107,9 +2097,7 @@ double DistMatrix<float>::trace(void) const
 #endif
     }
 
-#ifdef USE_MPI
     MPI_Bcast(&trace, 1, MPI_DOUBLE, 0, comm_global_);
-#endif
     return trace;
 }
 ////////////////////////////////////////////////////////////////////////////////
@@ -2565,9 +2553,7 @@ void DistMatrix<T>::print(std::ostream& os, const int ia, const int ja,
     BlacsContext bcl(comm_global_, 1, 1);
     DistMatrix<T> t("DistMatrix<T>::print", bcl, m, n);
 
-#ifdef USE_MPI
     MPI_Barrier(comm_global_);
-#endif
     t.getsub(*this, m, n, ia, ja);
     if (t.active())
     {
@@ -2595,9 +2581,7 @@ float DistMatrix<float>::getVal(const int i, const int j) const
 
     float val;
     if (active_) pselget(&scope, &top, &val, val_.data(), &ia, &ja, desc_);
-#ifdef USE_MPI
     MPI_Bcast(&val, 1, MPI_DOUBLE, 0, comm_global_);
-#endif
     return val;
 }
 
@@ -2612,9 +2596,7 @@ double DistMatrix<double>::getVal(const int i, const int j) const
 
     double val;
     if (active_) pdelget(&scope, &top, &val, val_.data(), &ia, &ja, desc_);
-#ifdef USE_MPI
     MPI_Bcast(&val, 1, MPI_FLOAT, 0, comm_global_);
-#endif
     return val;
 }
 

--- a/src/DistMatrix/DistMatrix.h
+++ b/src/DistMatrix/DistMatrix.h
@@ -21,11 +21,7 @@
 #include <string.h>
 #include <vector>
 
-#if USE_MPI
 #include <mpi.h>
-#else
-typedef int MPI_Comm;
-#endif
 
 #ifndef MGMOL_DISTMATRIX_ERROR
 

--- a/src/DistMatrix/MPI_AllToSome.cc
+++ b/src/DistMatrix/MPI_AllToSome.cc
@@ -8,8 +8,6 @@
 // This file is part of MGmol. For details, see https://github.com/llnl/mgmol.
 // Please also read this link https://github.com/llnl/mgmol/LICENSE
 
-#ifdef USE_MPI
-
 #include "mpi.h"
 #include <cassert>
 #include <iostream>
@@ -167,5 +165,3 @@ template int MPI_AlltofirstNv<int>(int* sendbuf, int* sendcnts, int* sdispls,
 template int MPI_AlltofirstNv<unsigned short>(unsigned short* sendbuf,
     int* sendcnts, int* sdispls, unsigned short* recvbuf, int* recvcnts,
     int* rdispls, const int nfirst, MPI_Comm comm);
-
-#endif

--- a/src/DistMatrix/MPI_DistMatrixCommunicator.h
+++ b/src/DistMatrix/MPI_DistMatrixCommunicator.h
@@ -11,11 +11,7 @@
 #ifndef MPI_DistMatrixCOMMUNICATOR_H
 #define MPI_DistMatrixCOMMUNICATOR_H
 
-#if USE_MPI
 #include <mpi.h>
-#else
-typedef int MPI_Comm;
-#endif
 
 namespace dist_matrix
 {

--- a/src/DistMatrix/MatricesBlacsContext.h
+++ b/src/DistMatrix/MatricesBlacsContext.h
@@ -16,9 +16,7 @@
 #include <cassert>
 #include <iostream>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 class MatricesBlacsContext
 {

--- a/src/DistMatrix/RemoteTasksDistMatrix.h
+++ b/src/DistMatrix/RemoteTasksDistMatrix.h
@@ -16,9 +16,7 @@
 #include <cassert>
 #include <climits>
 
-#if USE_MPI
 #include <mpi.h>
-#endif
 
 namespace dist_matrix
 {
@@ -33,11 +31,9 @@ private:
 public:
     RemoteTasksDistMatrix(DistMatrix<T>& mat)
     {
-        int npes = 1;
-#if USE_MPI
+        int npes            = 1;
         const MPI_Comm comm = mat.comm_global();
         MPI_Comm_size(comm, &npes);
-#endif
         const short mypr  = mat.myrow();
         const short mypc  = mat.mycol();
         const short nprow = mat.nprow();
@@ -45,14 +41,12 @@ public:
         my_task_index_ = mypr + mypc * nprow;
 
         remote_tasks_indexes_.resize(npes);
-#if USE_MPI
         if (npes > 1)
         {
             MPI_Allgather(&my_task_index_, 1, MPI_SHORT,
                 &remote_tasks_indexes_[0], 1, MPI_SHORT, comm);
         }
         else
-#endif
         {
             remote_tasks_indexes_[0] = my_task_index_;
         }

--- a/src/DistMatrix/SparseDistMatrix.h
+++ b/src/DistMatrix/SparseDistMatrix.h
@@ -17,11 +17,7 @@
 #ifndef MGMOL_SPARSEDISTMATRIX_H
 #define MGMOL_SPARSEDISTMATRIX_H
 
-#if USE_MPI
 #include <mpi.h>
-#else
-typedef int MPI_Comm;
-#endif
 
 #include "DistMatrix.h"
 #include "MPI_DistMatrixCommunicator.h"

--- a/src/DistMatrix/SubMatrices.cc
+++ b/src/DistMatrix/SubMatrices.cc
@@ -27,13 +27,8 @@ SubMatrices<T>::SubMatrices(const string& name,
     const SubMatricesIndexing<T>& submat_indexing)
     : object_name_(name), comm_(comm), submat_indexing_(submat_indexing)
 {
-#if USE_MPI
     MPI_Comm_size(comm_, &npes_);
     MPI_Comm_rank(comm_, &mype_);
-#else
-    npes_ = 1;
-    mype_ = 0;
-#endif
     npes_distmat_ = mat.nprow() * mat.npcol();
 
 #ifdef DEBUG
@@ -223,8 +218,6 @@ void SubMatrices<T>::gather(const DistMatrix<T>& mat)
 
     vector<T> buf_my_val(my_size, 0.);
 
-#ifdef USE_MPI
-
 #if 0
   // send/recv data 
   MPI_Alltoallv(&buf_remote_val[0],&remote_sizes_[0],&remote_displ[0],MPI_DOUBLE,
@@ -255,12 +248,6 @@ void SubMatrices<T>::gather(const DistMatrix<T>& mat)
     sendrecv(sendbuf, recvbuf, my_displ, remote_displ);
 
 #endif
-
-#else
-    assert((int)buf_remote_val.size() == nb_local_matrices_ * n_ * n_);
-    assert((int)buf_my_val.size() == nb_local_matrices_ * n_ * n_);
-    buf_my_val = buf_remote_val;
-#endif // USE_MPI
 
     gather_comm_tm_.stop();
     gather_comp_tm_.start();

--- a/src/DistMatrix/SubMatrices.h
+++ b/src/DistMatrix/SubMatrices.h
@@ -12,11 +12,7 @@
 #ifndef MGMOL_SubMatrices_H
 #define MGMOL_SubMatrices_H
 
-#if USE_MPI
 #include <mpi.h>
-#else
-typedef int MPI_Comm;
-#endif
 
 #include "DistMatrix.h"
 #include "SubMatricesIndexing.h"

--- a/src/DistMatrix/SubMatricesIndexing.h
+++ b/src/DistMatrix/SubMatricesIndexing.h
@@ -13,11 +13,7 @@
 
 #include "DistMatrix.h"
 
-#if USE_MPI
 #include <mpi.h>
-#else
-typedef int MPI_Comm;
-#endif
 
 #include <map>
 #include <vector>

--- a/src/DistMatrix/blacs.h
+++ b/src/DistMatrix/blacs.h
@@ -11,11 +11,7 @@
 #ifndef MGMOL_BLACS_H
 #define MGMOL_BLACS_H
 
-#if USE_MPI
 #include <mpi.h>
-#else
-typedef int MPI_Comm;
-#endif
 
 extern "C"
 {

--- a/src/DistributedIonicData.h
+++ b/src/DistributedIonicData.h
@@ -14,11 +14,9 @@
 #include "IonData.h"
 
 #include <iterator>
+#include <mpi.h>
 #include <string>
 #include <vector>
-#ifdef USE_MPI
-#include <mpi.h>
-#endif
 
 class DistributedIonicData
 {

--- a/src/ExtendedGridOrbitals.cc
+++ b/src/ExtendedGridOrbitals.cc
@@ -10,9 +10,7 @@
 
 #include "global.h"
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include "Control.h"
 #include "DistMatrix.h"

--- a/src/FIRE_IonicStepper.cc
+++ b/src/FIRE_IonicStepper.cc
@@ -121,11 +121,9 @@ int FIRE_IonicStepper::init(HDFrestart& h5f_file)
     }
 
     int n = (int)tau0_.size(), ione = 1;
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     mmpi.bcast(&tau0_[0], n);
     mmpi.bcast(&taup_[0], n);
-#endif
     DAXPY(&n, &dt_, &taup_[0], &ione, &tau0_[0], &ione);
 
     return 0;

--- a/src/FunctionsPacking.cc
+++ b/src/FunctionsPacking.cc
@@ -227,8 +227,5 @@ void FunctionsPacking::initOrbiOverlapGlobal(LocalizationRegions* lrs,
             orbi_overlap.setVal(gid1, gid2, oo1);
         }
     }
-#ifdef USE_MPI
     orbi_overlap.mpiAllOr();
-
-#endif
 }

--- a/src/GlobalLBFGS.cc
+++ b/src/GlobalLBFGS.cc
@@ -250,13 +250,11 @@ bool GlobalLBFGS::checkTolForces(const double tol)
         (*MPIdata::sout) << setprecision(3) << scientific
                          << "global_lbfgs: Max. |force| for image = "
                          << sqrt(f2) << endl;
-    int flag_convF = (f2 < tol * tol);
-#if USE_MPI
+    int flag_convF           = (f2 < tol * tol);
     Mesh* mymesh             = Mesh::instance();
     const pb::PEenv& myPEenv = mymesh->peenv();
     // make sure flag_convF is the same on all pes
     MPI_Bcast(&flag_convF, 1, MPI_INT, 0, myPEenv.comm());
-#endif
 
     return (flag_convF);
 }

--- a/src/GramMatrix.cc
+++ b/src/GramMatrix.cc
@@ -141,10 +141,8 @@ double GramMatrix::computeCond()
     double invcond = ls_->pocon('l', anorm);
     double cond    = 0.;
     if (onpe0) cond = 1. / invcond;
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     mmpi.bcast(&cond, 1);
-#endif
 #else
     double emin;
     double emax;

--- a/src/HDFrestart.h
+++ b/src/HDFrestart.h
@@ -180,9 +180,7 @@ public:
     hid_t file_id() const { return file_id_; }
     std::string filename() const { return filename_; }
     bool active() const { return active_; }
-#ifdef USE_MPI
     MPI_Comm& comm_active() { return comm_active_; }
-#endif
 
     ~HDFrestart();
     int close();

--- a/src/Ion.cc
+++ b/src/Ion.cc
@@ -15,9 +15,7 @@
 #include <iomanip>
 #include <iostream>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 unsigned short isqrt(unsigned value)
 {
@@ -128,15 +126,11 @@ void Ion::setup()
 
 void Ion::bcast(MPI_Comm comm)
 {
-#ifdef USE_MPI
     MPI_Bcast(old_position_, 3, MPI_DOUBLE, 0, comm);
     MPI_Bcast(position_, 3, MPI_DOUBLE, 0, comm);
     MPI_Bcast(force_, 3, MPI_DOUBLE, 0, comm);
     MPI_Bcast(velocity_, 3, MPI_DOUBLE, 0, comm);
     MPI_Bcast(&locked_, 1, MPI_CHAR, 0, comm);
-#else
-    return;
-#endif
 }
 
 void Ion::set_lstart(const int i, const double cell_origin, const double hgrid)

--- a/src/Ions.cc
+++ b/src/Ions.cc
@@ -20,9 +20,7 @@
 #include "mgmol_mpi_tools.h"
 #include "tools.h"
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include <cmath>
 #include <iostream>
@@ -484,7 +482,6 @@ double Ions::energyDiff(const short bc[3]) const
     }
     assert(energy == energy);
 
-#ifdef USE_MPI
     Mesh* mymesh             = Mesh::instance();
     const pb::PEenv& myPEenv = mymesh->peenv();
     double tenergy           = 0.;
@@ -493,7 +490,6 @@ double Ions::energyDiff(const short bc[3]) const
     // take half the result to account for double counting loop over
     // interacting_ions
     energy = 0.5 * tenergy;
-#endif
 
     return energy; // Hartree
 }
@@ -2130,9 +2126,7 @@ int Ions::readAtomsFromXYZ(
         aname.append(ss.str());
         Ion* new_ion
             = new Ion(species_[isp], aname, &crds[3 * ia], velocity, locked);
-#ifdef USE_MPI
         new_ion->bcast(mmpi.commGlobal());
-#endif
 
         // Populate list_ions_ list
         // std::cout<<"crds: "<<crds[3*ia+0]<<", "<<crds[3*ia+1]<<",

--- a/src/LBFGS_IonicStepper.cc
+++ b/src/LBFGS_IonicStepper.cc
@@ -64,15 +64,10 @@ LBFGS_IonicStepper::LBFGS_IonicStepper(const double dt,
     gndofs_ = tmp;
 
     m_ = min(m, gndofs_);
-#if USE_MPI
-    if (onpe0)
-#endif
-        (*MPIdata::sout) << " LBFGS with m=" << m_ << endl;
+    if (onpe0) (*MPIdata::sout) << " LBFGS with m=" << m_ << endl;
 
     freeze_geom_center_ = (3 * na == gndofs_);
-#if USE_MPI
     if (onpe0)
-#endif
         if (freeze_geom_center_)
             (*MPIdata::sout) << " LBFGS with geometry center frozen" << endl;
 
@@ -407,17 +402,13 @@ int LBFGS_IonicStepper::read_lbfgs(HDFrestart& h5f_file)
             }
         }
     }
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     mmpi.bcast(&check_data, 1);
-#endif
 
     // return 1 if no data read
     if (!check_data) return 1;
 
-#ifdef USE_MPI
     mmpi.bcast(&attr_d[0], 16);
-#endif
 
     if (onpe0) (*MPIdata::sout) << "Setup LBFGS using restart info" << endl;
 
@@ -498,9 +489,7 @@ int LBFGS_IonicStepper::read_lbfgs(HDFrestart& h5f_file)
             return -1;
         }
     }
-#ifdef USE_MPI
     mmpi.bcast(&attr_i[0], nb_attri);
-#endif
     iflag_              = attr_i[0];
     m_                  = attr_i[1];
     iter_               = attr_i[2];
@@ -550,9 +539,7 @@ int LBFGS_IonicStepper::read_lbfgs(HDFrestart& h5f_file)
         }
     }
 
-#ifdef USE_MPI
     mmpi.bcast(&u[0], dim);
-#endif
     int wsize = work_.size();
     int ione  = 1;
     DCOPY(&wsize, u, &ione, &work_[0], &ione);
@@ -623,11 +610,9 @@ int LBFGS_IonicStepper::init(HDFrestart& h5f_file)
     }
 
     int n = (int)tau0_.size(), ione = 1;
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     mmpi.bcast(&tau0_[0], n);
     mmpi.bcast(&taup_[0], n);
-#endif
     DAXPY(&n, &dt_, &taup_[0], &ione, &tau0_[0], &ione);
 
     int rlbfgs = read_lbfgs(h5f_file);

--- a/src/LBFGS_IonicStepper.h
+++ b/src/LBFGS_IonicStepper.h
@@ -18,9 +18,7 @@
 #ifndef LBFGS_IONICSTEPPER_H
 #define LBFGS_IONICSTEPPER_H
 
-#if USE_MPI
 #include "MPIdata.h"
-#endif
 
 #include "IonicStepper.h"
 #include "hdf5.h"

--- a/src/LDAFunctional.cc
+++ b/src/LDAFunctional.cc
@@ -115,7 +115,6 @@ double LDAFunctional::computeRhoDotExc() const
         }
         exc += (POTDTYPE)exc_temp;
     }
-#ifdef USE_MPI
     double sum      = 0.;
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     int rc          = mmpi.allreduce(&exc, &sum, 1, MPI_SUM);
@@ -126,7 +125,6 @@ double LDAFunctional::computeRhoDotExc() const
         ct.global_exit(2);
     }
     exc = (POTDTYPE)sum;
-#endif
     return exc;
 }
 

--- a/src/LocGridOrbitals.cc
+++ b/src/LocGridOrbitals.cc
@@ -10,9 +10,7 @@
 
 #include "global.h"
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include "ColoredRegions.h"
 #include "Control.h"
@@ -1246,7 +1244,6 @@ int LocGridOrbitals::read_func_hdf5(HDFrestart& h5f_file, const string& name)
 
         int intdims[2] = { dims[0], dims[1] };
 
-#ifdef USE_MPI
         if (h5f_file.gatherDataX())
         {
             // Bcast size of data and data
@@ -1257,7 +1254,6 @@ int LocGridOrbitals::read_func_hdf5(HDFrestart& h5f_file, const string& name)
             if (!mmpi.instancePE0()) attr_data.resize(dim);
             mmpi.bcast(&attr_data[0], dim);
         }
-#endif
 
         // loop over centers just read
         for (int i = 0; i < intdims[0]; i++)
@@ -1602,7 +1598,6 @@ void LocGridOrbitals::computeDiagonalElementsDotProductLocal(
                 diag.insertMatrixElement(ifunc, ifunc, val, ADD, true);
             }
         }
-#ifdef USE_MPI
     /* do data distribution to update local sums */
     (*distributor_diagdotprod_).augmentLocalData(diag, false);
     /* collect data */
@@ -1611,7 +1606,6 @@ void LocGridOrbitals::computeDiagonalElementsDotProductLocal(
     {
         ss.push_back((DISTMATDTYPE)diag.getRowEntry(row, 0));
     }
-#endif
 }
 
 void LocGridOrbitals::computeGram(

--- a/src/LocalMatrices2DistMatrix.cc
+++ b/src/LocalMatrices2DistMatrix.cc
@@ -94,14 +94,10 @@ template <class T>
 void LocalMatrices2DistMatrix::accumulate(const LocalMatrices<T>& src,
     dist_matrix::DistMatrix<T>& dst, const int numst, const double tol) const
 {
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     MPI_Comm comm   = mmpi.commSameSpin();
     dist_matrix::SparseDistMatrix<DISTMATDTYPE> sm(
         comm, dst, sparse_distmatrix_nb_tasks_per_partitions_);
-#else
-    dist_matrix::SparseDistMatrix<DISTMATDTYPE> sm(0, dst);
-#endif
 
     // convert into a SparseDistMatrix
     convert(src, sm, numst, tol);

--- a/src/LocalizationRegions.cc
+++ b/src/LocalizationRegions.cc
@@ -485,7 +485,6 @@ void LocalizationRegions::bcastLRs()
     if (ct.verbose > 0)
         printWithTimeStamp("LocalizationRegions::bcast()...", cout);
 
-#ifdef USE_MPI
     MGmol_MPI& mmpi(*(MGmol_MPI::instance()));
     MPI_Comm comm = mmpi.commSameSpin();
 
@@ -648,7 +647,6 @@ void LocalizationRegions::bcastLRs()
              << endl;
         MPI_Abort(comm, 0);
     }
-#endif
     if (ct.verbose > 0)
         printWithTimeStamp("LocalizationRegions::bcast() done...", cout);
 }
@@ -799,7 +797,6 @@ float LocalizationRegions::getStatesWithClosestCenters(
     }
 
     /* communicate info */
-#ifdef USE_MPI
     MGmol_MPI& mmpi(*(MGmol_MPI::instance()));
     MPI_Comm comm = mmpi.commSameSpin();
     int npes;
@@ -812,7 +809,6 @@ float LocalizationRegions::getStatesWithClosestCenters(
     *st1 = st[0];
     *st2 = st[1];
     mmpi.bcast(&drmin2, 1, rank);
-#endif
 
     if (onpe0) (*MPIdata::sout) << "drmin2=" << drmin2 << endl;
     return sqrt(drmin2);
@@ -1189,7 +1185,6 @@ void LocalizationRegions::getGidsGlobal(std::vector<int>& gids)
 void LocalizationRegions::syncCenters()
 {
     syncCenter_tm_.start();
-#ifdef USE_MPI
     MGmol_MPI& mmpi(*(MGmol_MPI::instance()));
     Control& ct = *(Control::instance());
     if (ct.verbose > 0)
@@ -1259,7 +1254,6 @@ void LocalizationRegions::syncCenters()
     /* compute volume */
     computeVolume();
 
-#endif
     if (ct.verbose > 0)
         printWithTimeStamp(
             "LocalizationRegions::syncCenters() done...", (*MPIdata::sout));

--- a/src/MGmol.cc
+++ b/src/MGmol.cc
@@ -695,11 +695,7 @@ void MGmol<T>::write_header()
 template <class T>
 void MGmol<T>::global_exit(int i)
 {
-#ifdef USE_MPI
     MPI_Abort(comm_, i);
-#else
-    abort();
-#endif
 }
 
 template <class T>
@@ -1005,14 +1001,12 @@ void MGmol<T>::setup()
 
     // Write header to stdout
     write_header();
-#ifdef USE_MPI
     if (ct.verbose > 5)
     {
         Mesh* mymesh             = Mesh::instance();
         const pb::PEenv& myPEenv = mymesh->peenv();
         myPEenv.printPEnames(os_);
     }
-#endif
 
     if (ct.verbose > 0) printWithTimeStamp("MGmol<T>::setup done...", os_);
 

--- a/src/MLWFTransform.cc
+++ b/src/MLWFTransform.cc
@@ -20,9 +20,7 @@
 #include "MGmol_MPI.h"
 #include "MLWFTransform.h"
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 using namespace std;
 
@@ -50,7 +48,6 @@ double MLWFTransform::spread2(int i, int j) const
         cs[1] = 0.;
     }
 
-#ifdef USE_MPI
     if (offset_ > 0 && ii != -1)
     {
         MPI_Send(&cs[0], 2, MPI_DOUBLE, 0, 0, comm_);
@@ -64,7 +61,6 @@ double MLWFTransform::spread2(int i, int j) const
 
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     mmpi.bcast(cs, 2);
-#endif
 
     return lby2pi * lby2pi - (cs[0] * cs[0] + cs[1] * cs[1]);
 }

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -17,9 +17,7 @@
 #include <cassert>
 #include <ostream>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 // Main Mesh structure
 class Mesh

--- a/src/MultipoleExpansion.cc
+++ b/src/MultipoleExpansion.cc
@@ -63,12 +63,10 @@ void MultipoleExpansion::get_monopole(RHODTYPE* rho)
     const double h2 = grid_.hgrid(2);
 
     qtotal_ *= (h0 * h1 * h2);
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     double tmp;
     mmpi.allreduce(&qtotal_, &tmp, 1, MPI_SUM);
     qtotal_ = tmp;
-#endif
     if (onpe0_)
         (*MPIdata::sout) << scientific
                          << "MultipoleExpansion::get_monopole(double*), Charge="
@@ -125,15 +123,8 @@ void MultipoleExpansion::get_dipole(RHODTYPE* rho)
         }
     }
 
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     mmpi.allreduce(&dipole[0], &dipole_moment_[0], 3, MPI_SUM);
-#else
-    for (short d = 0; d < 3; d++)
-    {
-        dipole_moment_[d] = dipole[d];
-    }
-#endif
     for (short d = 0; d < 3; d++)
         dipole_moment_[d] *= (h0 * h1 * h2);
 
@@ -198,15 +189,8 @@ void MultipoleExpansion::get_dipole(const pb::GridFunc<RHODTYPE>& rho)
         }
     }
 
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     mmpi.allreduce(&dipole[0], &dipole_moment_[0], 3, MPI_SUM);
-#else
-    for (short d = 0; d < 3; d++)
-    {
-        dipole_moment_[d] = dipole[d];
-    }
-#endif
     const double vel = (hspacing[0] * hspacing[1] * hspacing[2]);
     for (short d = 0; d < 3; d++)
         dipole_moment_[d] *= vel;
@@ -278,15 +262,8 @@ void MultipoleExpansion::computeQuadrupole(const pb::GridFunc<RHODTYPE>& rho)
         }
     }
 
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     mmpi.allreduce(&quadrupole[0], &quadrupole_moment_[0], 6, MPI_SUM);
-#else
-    for (short d = 0; d < 6; d++)
-    {
-        quadrupole_moment_[d] = quadrupole[d];
-    }
-#endif
     const double vel = (hspacing[0] * hspacing[1] * hspacing[2]);
     for (short d = 0; d < 6; d++)
         quadrupole_moment_[d] *= vel;
@@ -362,7 +339,6 @@ void MultipoleExpansion::resetOriginToChargeCenter(
     }
 
     // update origin_
-#ifdef USE_MPI
     double tmp[3]   = { 0., 0., 0. };
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     mmpi.allreduce(&charge_center[0], &tmp[0], 3, MPI_SUM);
@@ -375,13 +351,6 @@ void MultipoleExpansion::resetOriginToChargeCenter(
     {
         origin_[d] = tmp[d];
     }
-#else
-    for (short d = 0; d < 3; d++)
-    {
-        double tmp = charge_center[d];
-        origin_[d] = tmp;
-    }
-#endif
     if (onpe0_)
         (*MPIdata::sout)
             << "MultipoleExpansion::resetOriginToChargeCenter(), new origin_=("

--- a/src/OrbitalsTransform.cc
+++ b/src/OrbitalsTransform.cc
@@ -141,7 +141,6 @@ Vector3D OrbitalsTransform::center(int i) const
             v[i] += origin_[i];
     }
 
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     MPI_Status status;
     if (offset_ > 0 && ii != -1) MPI_Send(&v[0], NDIM, MPI_DOUBLE, 0, 0, comm_);
@@ -151,7 +150,6 @@ Vector3D OrbitalsTransform::center(int i) const
         MPI_Recv(&v[0], NDIM, MPI_DOUBLE, src, 0, comm_, &status);
     }
     mmpi.bcast(&v[0], NDIM);
-#endif
     return v;
 }
 

--- a/src/PBEFunctional.cc
+++ b/src/PBEFunctional.cc
@@ -166,7 +166,6 @@ double PBEFunctional::computeRhoDotExc() const
             exc += prho_dn_[i] * pexc_dn_[i];
         }
     }
-#ifdef USE_MPI
     double sum      = 0.;
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     int rc          = mmpi.allreduce(&exc, &sum, 1, MPI_SUM);
@@ -177,7 +176,6 @@ double PBEFunctional::computeRhoDotExc() const
         ct.global_exit(2);
     }
     exc = sum;
-#endif
     return exc;
 }
 

--- a/src/Potentials.cc
+++ b/src/Potentials.cc
@@ -177,7 +177,6 @@ double Potentials::update(const vector<vector<RHODTYPE>>& rho)
 
     double dvdot = MPdot(size_, &dv_[0], &dv_[0]);
 
-#ifdef USE_MPI
     double sum = 0.;
     int rc
         = MPI_Allreduce(&dvdot, &sum, 1, MPI_DOUBLE, MPI_SUM, myPEenv.comm());
@@ -187,7 +186,6 @@ double Potentials::update(const vector<vector<RHODTYPE>>& rho)
         MPI_Abort(myPEenv.comm(), 2);
     }
     dvdot = sum;
-#endif
 
     scf_dv_            = 0.5 * sqrt(dvdot);
     const double gsize = (double)size_ * (double)myPEenv.n_mpi_tasks();
@@ -242,7 +240,6 @@ double Potentials::delta_v(const vector<vector<RHODTYPE>>& rho)
 
     double dvdot = MPdot(size_, &dv_[0], &dv_[0]);
 
-#ifdef USE_MPI
     double sum = 0.;
     int rc
         = MPI_Allreduce(&dvdot, &sum, 1, MPI_DOUBLE, MPI_SUM, myPEenv.comm());
@@ -252,7 +249,6 @@ double Potentials::delta_v(const vector<vector<RHODTYPE>>& rho)
         MPI_Abort(myPEenv.comm(), 2);
     }
     dvdot = sum;
-#endif
 
     scf_dv_            = 0.5 * sqrt(dvdot);
     const double gsize = (double)size_ * (double)myPEenv.n_mpi_tasks();

--- a/src/ProjectedMatrices.cc
+++ b/src/ProjectedMatrices.cc
@@ -136,14 +136,10 @@ void ProjectedMatrices::setup(const double kbt, const int nel,
 
 #endif
 
-#ifdef USE_MPI
     dist_matrix::DistMatrix<DISTMATDTYPE> tmp("tmp", ct.numst, ct.numst);
 
     sH_ = new dist_matrix::SparseDistMatrix<DISTMATDTYPE>(
         comm, *matH_, sparse_distmatrix_nb_partitions);
-#else
-    sH_ = new dist_matrix::SparseDistMatrix<DISTMATDTYPE>(0, *matH_);
-#endif
 }
 
 void ProjectedMatrices::computeInvS()
@@ -521,10 +517,8 @@ double ProjectedMatrices::checkCond(const double tol, const bool flag)
         // ofstream tfile("s.mm", ios::out);
         // gm_->printMM(tfile);
         // tfile.close();
-#ifdef USE_MPI
         MGmol_MPI& mgmolmpi = *(MGmol_MPI::instance());
         mgmolmpi.barrier();
-#endif
         if (onpe0)
             (*MPIdata::sout)
                 << " CONDITION NUMBER OF THE OVERLAP MATRIX EXCEEDS TOL: "

--- a/src/ProjectedMatricesMehrstellen.cc
+++ b/src/ProjectedMatricesMehrstellen.cc
@@ -48,21 +48,17 @@ void ProjectedMatricesMehrstellen::computeInvB()
         if (onpe0)
             (*MPIdata::sout) << "ProjectedMatrices::computeInvB()" << endl;
 #endif
-        *invB_    = *matB_;
-        int info1 = invB_->potrf('l');
-#ifdef USE_MPI
+        *invB_          = *matB_;
+        int info1       = invB_->potrf('l');
         MGmol_MPI& mmpi = *(MGmol_MPI::instance());
         mmpi.bcast(&info1, 1);
-#endif
         if (info1 != 0)
         {
             if (onpe0) (*MPIdata::serr) << "Matrix: " << matB_->name() << endl;
             matB_->printMM((*MPIdata::serr));
         }
         int info2 = invB_->potri('l');
-#ifdef USE_MPI
         mmpi.bcast(&info2, 1);
-#endif
         if (info2 != 0 && onpe0)
         {
             (*MPIdata::serr) << "Matrix: " << matB_->name() << endl;

--- a/src/ProjectedMatricesSparse.h
+++ b/src/ProjectedMatricesSparse.h
@@ -370,10 +370,8 @@ public:
             // ofstream tfile("s.mm", ios::out);;
             // gm_->printMM(tfile);
             // tfile.close();
-#ifdef USE_MPI
             MGmol_MPI& mgmolmpi = *(MGmol_MPI::instance());
             mgmolmpi.barrier();
-#endif
             if (onpe0)
                 (*MPIdata::sout)
                     << " CONDITION NUMBER OF THE OVERLAP MATRIX EXCEEDS TOL: "

--- a/src/ReplicatedWorkSpace.cc
+++ b/src/ReplicatedWorkSpace.cc
@@ -13,9 +13,7 @@
 #include "MGmol_MPI.h"
 #include "MGmol_blas1.h"
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 template <class T>
 Timer ReplicatedWorkSpace<T>::mpisum_tm_("ReplicatedWorkSpace::mpisum");
@@ -31,11 +29,9 @@ ReplicatedWorkSpace<T>& ReplicatedWorkSpace<T>::instance()
 template <class T>
 void ReplicatedWorkSpace<T>::mpiBcastSquareMatrix()
 {
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     int n2          = ndim_ * ndim_;
     mmpi.bcast(square_matrix_, n2, 0);
-#endif
     return;
 }
 

--- a/src/ShortSightedInverse.cc
+++ b/src/ShortSightedInverse.cc
@@ -18,9 +18,7 @@
 #include <string>
 #include <vector>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include "Control.h"
 #include "LinearSolverMatrix.h"

--- a/src/ShortSightedInverse.h
+++ b/src/ShortSightedInverse.h
@@ -17,9 +17,7 @@
 
 #include <vector>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include "ClusterOrbitals.h"
 #include "DataDistribution.h"

--- a/src/Species.cc
+++ b/src/Species.cc
@@ -211,7 +211,6 @@ void Species::read_1species(const string& filename)
 #endif
     }
 
-#ifdef USE_MPI
     int mpirc = MPI_Bcast(buf_name, size_buf, MPI_CHAR, 0, comm_);
     if (mpirc != MPI_SUCCESS)
     {
@@ -225,7 +224,6 @@ void Species::read_1species(const string& filename)
         MPI_Bcast(&h2s_, 1, MPI_DOUBLE, 0, comm_);
         MPI_Bcast(&h1p_, 1, MPI_DOUBLE, 0, comm_);
     }
-#endif
     assert(n_rad_points_ > 0);
     assert(num_potentials_ > 0);
     assert(llocal_ < num_potentials_);

--- a/src/computeHij.cc
+++ b/src/computeHij.cc
@@ -187,15 +187,10 @@ void MGmol<T>::computeHij_private(T& orbitals_i, T& orbitals_j,
 #ifdef PRINT_OPERATIONS
     if (onpe0) os_ << "computeHij()" << endl;
 #endif
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     MPI_Comm comm   = mmpi.commSameSpin();
     dist_matrix::SparseDistMatrix<DISTMATDTYPE> sparseH(
         comm, hij, sparse_distmatrix_nb_partitions);
-#else
-    dist_matrix::SparseDistMatrix<DISTMATDTYPE> sparseH(
-        0, hij, rtasks_distmatrix);
-#endif
 
     kbpsi_i->computeHvnlMatrix(kbpsi_j, ions, sparseH);
 
@@ -238,15 +233,10 @@ void MGmol<T>::computeHij_private(T& orbitals_i, T& orbitals_j,
 #ifdef PRINT_OPERATIONS
     if (onpe0) os_ << "computeHij()" << endl;
 #endif
-#ifdef USE_MPI
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     MPI_Comm comm   = mmpi.commSameSpin();
     dist_matrix::SparseDistMatrix<DISTMATDTYPE> sparseH(
         comm, hij, sparse_distmatrix_nb_partitions);
-#else
-    dist_matrix::SparseDistMatrix<DISTMATDTYPE> sparseH(
-        0, hij, rtasks_distmatrix);
-#endif
 
     kbpsi->computeHvnlMatrix(ions, sparseH);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -38,9 +38,7 @@ using namespace std;
 #include <mkl.h>
 #endif
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include "Control.h"
 #include "DistMatrix.h"
@@ -86,7 +84,6 @@ int main(int argc, char** argv)
 
     cout.sync_with_stdio();
 
-#ifdef USE_MPI
     int mpirc = MPI_Init(&argc, &argv);
     if (mpirc != MPI_SUCCESS)
     {
@@ -96,7 +93,6 @@ int main(int argc, char** argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &mype);
     assert(mype > -1);
     onpe0 = (mype == 0);
-#endif
 
 #ifdef HAVE_MAGMA
     magma_int_t magmalog;
@@ -703,9 +699,7 @@ int main(int argc, char** argv)
 
 #endif
 
-#ifdef USE_MPI
     mpirc = MPI_Finalize();
-#endif
 
     time_t tt;
     time(&tt);

--- a/src/md.cc
+++ b/src/md.cc
@@ -373,9 +373,7 @@ void MGmol<T>::md(T** orbitals, Ions& ions)
                 flag_extrapolated_data
                     = h5f_file_->dset_exists("ExtrapolatedFunction0");
         }
-#ifdef USE_MPI
         MPI_Bcast(&flag_extrapolated_data, 1, MPI_INT, 0, comm_);
-#endif
 
         if (ct.restart_info > 2)
         {

--- a/src/pb/GridFuncVector.cc
+++ b/src/pb/GridFuncVector.cc
@@ -55,11 +55,7 @@ void GridFuncVector<T>::setup()
     west_  = (bc_[0] == 1 || (grid_.mype_env().mpi_neighbors(WEST) < mytask));
 
     nfunc_ = (int)gid_[0].size();
-#ifdef USE_MPI
     MPI_Allreduce(&nfunc_, &nfunc_max_global_, 1, MPI_INT, MPI_MAX, comm_);
-#else
-    nfunc_max_global_ = nfunc_;
-#endif
     nsubdivx_ = (short)gid_.size();
 
     remote_gids_.resize(6);
@@ -1147,7 +1143,6 @@ void GridFuncVector<T>::trade_boundaries_colors(
 
     const size_t sdimz = dimz_ * sizeof(T);
 
-#ifdef USE_MPI
     communicateRemoteGids(first_color, last_color);
 
     const int ione = 1;
@@ -1364,9 +1359,7 @@ void GridFuncVector<T>::trade_boundaries_colors(
             assert((buf3_ptr - &comm_buf3[0]) <= static_cast<int>(sizebuffer));
         }
     }
-    else
-#endif
-        if (bc_[1] == 1)
+    else if (bc_[1] == 1)
     { // grid_.mype_env().n_mpi_task(1)==1
 
         // only for i already initialized
@@ -1388,7 +1381,6 @@ void GridFuncVector<T>::trade_boundaries_colors(
 
     int iinit = (dimy_ + 2 * nghosts_) * nghosts_;
 
-#ifdef USE_MPI
     if (grid_.mype_env().n_mpi_task(2) > 1)
     {
 
@@ -1564,9 +1556,7 @@ void GridFuncVector<T>::trade_boundaries_colors(
             }
         }
     }
-    else
-#endif
-        if (bc_[2] == 1)
+    else if (bc_[2] == 1)
     { /* grid_.mype_env().n_mpi_task(2)==1 */
 
         for (short color = first_color; color < end_color; color++)
@@ -1587,8 +1577,6 @@ void GridFuncVector<T>::trade_boundaries_colors(
 
     const int east_west_size_        = nghosts_ * incx_;
     const size_t east_west_size_data = east_west_size_ * sizeof(T);
-
-#ifdef USE_MPI
 
     if (grid_.mype_env().n_mpi_task(0) > 1)
     {
@@ -1727,9 +1715,7 @@ void GridFuncVector<T>::trade_boundaries_colors(
             }
         }
     }
-    else
-#endif
-        if (bc_[0] == 1)
+    else if (bc_[0] == 1)
     { /* grid_.mype_env().n_mpi_task(0)==1 */
 
         for (short color = first_color; color < end_color; color++)

--- a/src/pb/GridFuncVector.h
+++ b/src/pb/GridFuncVector.h
@@ -71,11 +71,9 @@ class GridFuncVector : public GridFuncVectorInterface
     static std::vector<std::vector<T>> comm_buf3_;
     static std::vector<std::vector<T>> comm_buf4_;
 
-#ifdef USE_MPI
     MPI_Request req_east_west_[4];
     MPI_Request req_north_south_[4];
     MPI_Request req_up_down_[4];
-#endif
 
     void wait_north_south();
     void wait_east_west();

--- a/src/pb/PEenv.h
+++ b/src/pb/PEenv.h
@@ -15,11 +15,7 @@
 #include <iostream>
 #include <unistd.h>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#else
-typedef int MPI_Comm;
-#endif
 
 namespace pb
 {

--- a/src/pb/TriCubic.cc
+++ b/src/pb/TriCubic.cc
@@ -209,14 +209,8 @@ void TriCubic<T>::getValues(
                  << endl;
         }
     }
-    //#ifdef USE_MPI
-    //    vector<double> tmp(val);
-    //    //cout<<"TriCubic::getValues(), MPI_Allreduce,
-    //    tmp.size()="<<tmp.size()<<endl; MPI_Allreduce(&tmp[0], &val[0], n,
-    //    MPI_DOUBLE, MPI_SUM, comm);
-    //#endif
-    return;
 }
+
 template <class T>
 void TriCubic<T>::getGradient(const double r[3], double dfdr[3], MPI_Comm comm)
 {
@@ -278,13 +272,6 @@ void TriCubic<T>::getGradient(const double r[3], double dfdr[3], MPI_Comm comm)
         cout << "WARNING: TriCubic::getGradient(), position outside domain..."
              << endl;
     }
-    //#ifdef USE_MPI
-    //    double tmp[3]={0.,0.,0.};
-    //    MPI_Allreduce(dfdr, tmp, 3, MPI_DOUBLE, MPI_SUM, comm);
-    //    for(short i=0;i<3;i++){
-    //        dfdr[i]=tmp[i];
-    //    }
-    //#endif
 }
 template class TriCubic<double>;
 template class TriCubic<float>;

--- a/src/pb/TriCubic.h
+++ b/src/pb/TriCubic.h
@@ -17,11 +17,7 @@
 
 #ifdef HAVE_TRICUBIC
 
-#ifdef USE_MPI
 #include <mpi.h>
-#else
-typedef int MPI_Comm;
-#endif
 
 namespace pb
 {

--- a/src/pb/solvePoisson.cc
+++ b/src/pb/solvePoisson.cc
@@ -10,9 +10,7 @@
 
 #include <iostream>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include "GridFunc.h"
 #include "Laph4M.h"
@@ -89,10 +87,6 @@ extern "C"
             return;
         }
 
-#ifdef USE_MPI
-//    int mype;
-//    MPI_Comm_rank(MPI_COMM_WORLD, &mype);
-#endif
         // leading dimension
         const int ldz = *nz;
 
@@ -166,7 +160,6 @@ extern "C"
             }
             delete myGrid;
         }
-#ifdef USE_MPI
         int npes;
         MPI_Comm_size(MPI_COMM_WORLD, &npes);
         // Send data to PE outside of solver partition
@@ -194,7 +187,6 @@ extern "C"
                     MPI_COMM_WORLD, &status);
             }
         }
-#endif
     }
 }
 

--- a/src/radial/RadialMeshFunction.cc
+++ b/src/radial/RadialMeshFunction.cc
@@ -71,7 +71,6 @@ void RadialMeshFunction::read(
     invdr_ = 1. / drlin_;
 }
 
-#ifdef USE_MPI
 void RadialMeshFunction::bcast(MPI_Comm comm, const int root)
 {
     int mpi_rank;
@@ -116,9 +115,6 @@ void RadialMeshFunction::bcast(MPI_Comm comm, const int root)
         }
     }
 }
-#else
-void RadialMeshFunction::bcast(MPI_Comm comm, const int root) { return; }
-#endif
 
 // radial integratation of f
 double RadialMeshFunction::radint(const int j)

--- a/src/readInput.cc
+++ b/src/readInput.cc
@@ -12,9 +12,7 @@
 #include <iostream>
 #include <string>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include "Control.h"
 #include "Ions.h"

--- a/src/restart.cc
+++ b/src/restart.cc
@@ -16,9 +16,7 @@
 #include <iostream>
 #include <vector>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include "Control.h"
 #include "HDFrestart.h"

--- a/src/sparse_linear_algebra/DataDistribution.cc
+++ b/src/sparse_linear_algebra/DataDistribution.cc
@@ -20,9 +20,7 @@
 #include <iomanip>
 #include <iostream>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 Timer DataDistribution::gathersizes_tm_("DataDistribution::gatherDataSizes");
 Timer DataDistribution::reducesizes_tm_("DataDistribution::reduceDataSizes");

--- a/src/sparse_linear_algebra/DataDistribution.h
+++ b/src/sparse_linear_algebra/DataDistribution.h
@@ -16,9 +16,7 @@
 #include "PEenv.h"
 #include "VariableSizeMatrix.h"
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include <iostream>
 

--- a/src/sparse_linear_algebra/PackedCommunicationBuffer.cc
+++ b/src/sparse_linear_algebra/PackedCommunicationBuffer.cc
@@ -19,9 +19,7 @@
 #include <iomanip>
 #include <iostream>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 Timer PackedCommunicationBuffer::pack_local_data_tm_(
     "PackedCommunicationBuffer::packLocalData");

--- a/src/sparse_linear_algebra/PackedCommunicationBuffer.h
+++ b/src/sparse_linear_algebra/PackedCommunicationBuffer.h
@@ -13,9 +13,7 @@
 
 #include "VariableSizeMatrix.h"
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 class PackedCommunicationBuffer
 {

--- a/src/sparse_linear_algebra/PreconILU.cc
+++ b/src/sparse_linear_algebra/PreconILU.cc
@@ -11,9 +11,7 @@
 #include <iostream>
 #include <vector>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include "LinearSolverMatrix.h"
 #include "MPIdata.h"

--- a/src/sparse_linear_algebra/SparseRow.cc
+++ b/src/sparse_linear_algebra/SparseRow.cc
@@ -20,9 +20,7 @@
 #include <iostream>
 #include <vector>
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 int SparseRow::updateRow(const int count, const int* const cols,
     const double* const vals, const INSERTMODE mode)

--- a/src/sparse_linear_algebra/SparseRowAndTable.cc
+++ b/src/sparse_linear_algebra/SparseRowAndTable.cc
@@ -19,10 +19,8 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <vector>
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
+#include <vector>
 
 void SparseRowAndTable::assign(
     std::vector<int>& coldata, std::vector<double>& colvals)

--- a/src/sparse_linear_algebra/VariableSizeMatrix.cc
+++ b/src/sparse_linear_algebra/VariableSizeMatrix.cc
@@ -22,10 +22,8 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <vector>
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
+#include <vector>
 
 Timer VariableSizeMatrixInterface::AmultSymBdiag_tm_(
     "VariableSizeMatrix::AmultSymBdiag");

--- a/src/tools/MGmol_MPI.cc
+++ b/src/tools/MGmol_MPI.cc
@@ -44,14 +44,12 @@ short MGmol_MPI::nimages_ = -1;
 
 MGmol_MPI::MGmol_MPI()
 {
-#ifdef USE_MPI
     assert(comm_spin_ != MPI_COMM_NULL);
 
     MPI_Comm_size(comm_spin_, &size_);
     MPI_Comm_rank(comm_spin_, &mype_spin_);
     if (mype_spin_ == 0)
         *os_ << "MGmol instance using " << size_ << " MPI tasks" << std::endl;
-#endif
 }
 
 void MGmol_MPI::printTimers(std::ostream& os)
@@ -164,115 +162,83 @@ void MGmol_MPI::setupComm(
 
 int MGmol_MPI::bcast(double* val, int size, int root) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Bcast(val, size, MPI_DOUBLE, root, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR(
             "ERROR in MPI_Bcast(double*, int) of size " << size << "!!!");
     }
-#else
-    int mpi_err = 0;
-#endif
     return mpi_err;
 }
 
 int MGmol_MPI::bcast(float* val, int size, int root) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Bcast(val, size, MPI_FLOAT, root, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR(
             "ERROR in MPI_Bcast(float*, int) of size " << size << "!!!");
     }
-#else
-    int mpi_err = 0;
-#endif
     return mpi_err;
 }
 
 int MGmol_MPI::bcast(int* val, int size, int root) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Bcast(val, size, MPI_INT, root, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR("MPI_Bcast(int*, int) of size " << size << "!!!");
     }
-#else
-    int mpi_err = 0;
-#endif
     return mpi_err;
 }
 
 int MGmol_MPI::bcast(short* val, int size, int root) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Bcast(val, size, MPI_SHORT, root, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR("MPI_Bcast(short*, int) of size " << size << "!!!");
     }
-#else
-    int mpi_err = 0;
-#endif
     return mpi_err;
 }
 
 int MGmol_MPI::bcastGlobal(double* val, int size, int root) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Bcast(val, size, MPI_DOUBLE, root, comm_global_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR("MPI_Bcast(double*, int) of size " << size << "!!!");
     }
-#else
-    int mpi_err = 0;
-#endif
     return mpi_err;
 }
 
 int MGmol_MPI::bcastGlobal(short* val, int size, int root) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Bcast(val, size, MPI_SHORT, root, comm_global_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR("MPI_Bcast(short*, int) of size " << size << "!!!");
     }
-#else
-    int mpi_err = 0;
-#endif
     return mpi_err;
 }
 
 int MGmol_MPI::bcastGlobal(int* val, int size, int root) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Bcast(val, size, MPI_INT, root, comm_global_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR("MPI_Bcast(short*, int) of size " << size << "!!!");
     }
-#else
-    int mpi_err = 0;
-#endif
     return mpi_err;
 }
 
 int MGmol_MPI::bcast(char* val, int size, int root) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Bcast(val, size, MPI_CHAR, root, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR("MPI_Bcast(char*, int) of size " << size << "!!!");
     }
-#else
-    int mpi_err = 0;
-#endif
     return mpi_err;
 }
 
@@ -303,7 +269,6 @@ int MGmol_MPI::reduce(
 int MGmol_MPI::allreduce(
     double* sendbuf, double* recvbuf, int count, MPI_Op op) const
 {
-#ifdef USE_MPI
     int mpi_err
         = MPI_Allreduce(sendbuf, recvbuf, count, MPI_DOUBLE, op, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
@@ -312,15 +277,11 @@ int MGmol_MPI::allreduce(
             "MPI_Allreduce(double*, double*) of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allreduce(
     float* sendbuf, float* recvbuf, int count, MPI_Op op) const
 {
-#ifdef USE_MPI
     int mpi_err
         = MPI_Allreduce(sendbuf, recvbuf, count, MPI_FLOAT, op, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
@@ -329,14 +290,10 @@ int MGmol_MPI::allreduce(
             "MPI_Allreduce(float*, float*) of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allreduce(int* sendbuf, int* recvbuf, int count, MPI_Op op) const
 {
-#ifdef USE_MPI
     int mpi_err
         = MPI_Allreduce(sendbuf, recvbuf, count, MPI_INT, op, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
@@ -344,15 +301,11 @@ int MGmol_MPI::allreduce(int* sendbuf, int* recvbuf, int count, MPI_Op op) const
         MGMOL_MPI_ERROR("MPI_Allreduce(int*, int*) of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allreduce(
     short* sendbuf, short* recvbuf, int count, MPI_Op op) const
 {
-#ifdef USE_MPI
     int mpi_err
         = MPI_Allreduce(sendbuf, recvbuf, count, MPI_SHORT, op, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
@@ -360,15 +313,11 @@ int MGmol_MPI::allreduce(
         MGMOL_MPI_ERROR("MPI_Allreduce(int*, int*) of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allreduceGlobal(
     int* sendbuf, int* recvbuf, int count, MPI_Op op) const
 {
-#ifdef USE_MPI
     int mpi_err
         = MPI_Allreduce(sendbuf, recvbuf, count, MPI_INT, op, comm_global_);
     if (mpi_err != MPI_SUCCESS)
@@ -376,15 +325,11 @@ int MGmol_MPI::allreduceGlobal(
         MGMOL_MPI_ERROR("MPI_Allreduce(int*, int*) of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allreduceGlobal(
     double* sendbuf, double* recvbuf, int count, MPI_Op op) const
 {
-#ifdef USE_MPI
     int mpi_err
         = MPI_Allreduce(sendbuf, recvbuf, count, MPI_DOUBLE, op, comm_global_);
     if (mpi_err != MPI_SUCCESS)
@@ -392,9 +337,6 @@ int MGmol_MPI::allreduceGlobal(
         MGMOL_MPI_ERROR("MPI_Allreduce(int*, int*) of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::getRankMinVal(const double val, int* rank)
@@ -442,7 +384,6 @@ int MGmol_MPI::getRankMaxVal(const float val, int* rank)
 int MGmol_MPI::allreduceImages(
     double* sendbuf, double* recvbuf, int count, MPI_Op op) const
 {
-#ifdef USE_MPI
     int mpi_err
         = MPI_Allreduce(sendbuf, recvbuf, count, MPI_DOUBLE, op, comm_images_);
     if (mpi_err != MPI_SUCCESS)
@@ -451,9 +392,6 @@ int MGmol_MPI::allreduceImages(
             "MPI_Allreduce(double*, double*) of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::reduce(double* buf, int count, MPI_Op op, const int root) const
@@ -582,7 +520,6 @@ int MGmol_MPI::allreduceSpin(
 {
     if (nspin_ == 1) return 0;
 
-#ifdef USE_MPI
     assert(comm_different_spin_ != MPI_COMM_NULL);
     int mpi_err = MPI_Allreduce(
         sendbuf, recvbuf, count, MPI_DOUBLE, op, comm_different_spin_);
@@ -592,9 +529,6 @@ int MGmol_MPI::allreduceSpin(
             "MPI_Allreduce(double*, double*) of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allreduceSpin(
@@ -602,7 +536,6 @@ int MGmol_MPI::allreduceSpin(
 {
     if (nspin_ == 1) return 0;
 
-#ifdef USE_MPI
     assert(comm_different_spin_ != MPI_COMM_NULL);
     int mpi_err = MPI_Allreduce(
         sendbuf, recvbuf, count, MPI_FLOAT, op, comm_different_spin_);
@@ -612,9 +545,6 @@ int MGmol_MPI::allreduceSpin(
             "MPI_Allreduce(double*, double*) of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::exchangeDataSpin(
@@ -626,7 +556,6 @@ int MGmol_MPI::exchangeDataSpin(
     assert(remotedata != 0);
     assert(myspin_ == 0 || myspin_ == 1);
 
-#ifdef USE_MPI
     assert(comm_different_spin_ != MPI_COMM_NULL);
     MPI_Request requestr;
     int src = (myspin_ + 1) % 2;
@@ -654,9 +583,6 @@ int MGmol_MPI::exchangeDataSpin(
     // barrier();
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::exchangeDataSpin(
@@ -668,7 +594,6 @@ int MGmol_MPI::exchangeDataSpin(
     assert(remotedata != 0);
     assert(myspin_ == 0 || myspin_ == 1);
 
-#ifdef USE_MPI
     assert(comm_different_spin_ != MPI_COMM_NULL);
     MPI_Request requestr;
     int src = (myspin_ + 1) % 2;
@@ -696,9 +621,6 @@ int MGmol_MPI::exchangeDataSpin(
     // barrier();
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 bool MGmol_MPI::compareSpin(const double val)
@@ -718,21 +640,16 @@ bool MGmol_MPI::compareSpin(const double val)
 
 int MGmol_MPI::send(double* sendbuf, int count, int dest) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Send(sendbuf, count, MPI_DOUBLE, dest, 0, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR("MPI_Send() of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::recv(double* recvbuf, int count, int src) const
 {
-#ifdef USE_MPI
     MPI_Status status;
     int mpi_err
         = MPI_Recv(recvbuf, count, MPI_DOUBLE, src, 0, comm_spin_, &status);
@@ -741,28 +658,20 @@ int MGmol_MPI::recv(double* recvbuf, int count, int src) const
         MGMOL_MPI_ERROR("MPI_Recv() of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::send(float* sendbuf, int count, int dest) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Send(sendbuf, count, MPI_FLOAT, dest, 0, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR("MPI_Send() of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::recv(float* recvbuf, int count, int src) const
 {
-#ifdef USE_MPI
     MPI_Status status;
     int mpi_err
         = MPI_Recv(recvbuf, count, MPI_FLOAT, src, 0, comm_spin_, &status);
@@ -771,28 +680,20 @@ int MGmol_MPI::recv(float* recvbuf, int count, int src) const
         MGMOL_MPI_ERROR("MPI_Recv() of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::send(int* sendbuf, int count, int dest) const
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Send(sendbuf, count, MPI_INT, dest, 0, comm_spin_);
     if (mpi_err != MPI_SUCCESS)
     {
         MGMOL_MPI_ERROR("MPI_Send() of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::recv(int* recvbuf, int count, int src) const
 {
-#ifdef USE_MPI
     MPI_Status status;
     int mpi_err
         = MPI_Recv(recvbuf, count, MPI_INT, src, 0, comm_spin_, &status);
@@ -801,9 +702,6 @@ int MGmol_MPI::recv(int* recvbuf, int count, int src) const
         MGMOL_MPI_ERROR("MPI_Recv() of size " << count << "!!!");
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::bcast(std::string& common_string) const
@@ -818,7 +716,6 @@ int MGmol_MPI::bcastGlobal(std::string& common_string) const
 
 int MGmol_MPI::bcast(std::string& common_string, MPI_Comm comm) const
 {
-#ifdef USE_MPI
     short size_str = (short)common_string.size();
     int mpi_err    = MPI_Bcast(&size_str, 1, MPI_SHORT, 0, comm);
     if (mpi_err != MPI_SUCCESS)
@@ -842,15 +739,11 @@ int MGmol_MPI::bcast(std::string& common_string, MPI_Comm comm) const
     common_string.assign(&buffer[0], size_str);
     delete[] buffer;
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::gather(
     double* sendbuf, int s_count, double* recvbuf, int recvbufsize, int root)
 {
-#ifdef USE_MPI
     assert(s_count * size_ == recvbufsize);
     int count   = s_count;
     int mpi_err = MPI_Gather(sendbuf, count, MPI_DOUBLE, recvbuf, count,
@@ -861,15 +754,11 @@ int MGmol_MPI::gather(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::gather(
     float* sendbuf, int s_count, float* recvbuf, int recvbufsize, int root)
 {
-#ifdef USE_MPI
     assert(s_count * size_ == recvbufsize);
     int count   = s_count;
     int mpi_err = MPI_Gather(
@@ -880,15 +769,11 @@ int MGmol_MPI::gather(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::gather(
     int* sendbuf, int s_count, int* recvbuf, int recvbufsize, int root)
 {
-#ifdef USE_MPI
     assert(s_count * size_ == recvbufsize);
     int count   = s_count;
     int mpi_err = MPI_Gather(
@@ -899,15 +784,11 @@ int MGmol_MPI::gather(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGather(
     std::vector<double>& sendbuf, std::vector<double>& recvbuf)
 {
-#ifdef USE_MPI
     assert(sendbuf.size() * size_ == recvbuf.size());
     int count   = (int)sendbuf.size();
     int mpi_err = MPI_Allgather(&sendbuf[0], count, MPI_DOUBLE, &recvbuf[0],
@@ -919,14 +800,10 @@ int MGmol_MPI::allGather(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGather(std::vector<int>& sendbuf, std::vector<int>& recvbuf)
 {
-#ifdef USE_MPI
     assert(sendbuf.size() * size_ == recvbuf.size());
     int count   = (int)sendbuf.size();
     int mpi_err = MPI_Allgather(
@@ -937,15 +814,11 @@ int MGmol_MPI::allGather(std::vector<int>& sendbuf, std::vector<int>& recvbuf)
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGather(
     double* sendbuf, int s_count, double* recvbuf, int recvbufsize)
 {
-#ifdef USE_MPI
     assert(s_count * size_ == recvbufsize);
     int count   = s_count;
     int mpi_err = MPI_Allgather(
@@ -956,15 +829,11 @@ int MGmol_MPI::allGather(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGather(
     float* sendbuf, int s_count, float* recvbuf, int recvbufsize)
 {
-#ifdef USE_MPI
     assert(s_count * size_ == recvbufsize);
     int count   = s_count;
     int mpi_err = MPI_Allgather(
@@ -975,15 +844,11 @@ int MGmol_MPI::allGather(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGather(
     int* sendbuf, int s_count, int* recvbuf, int recvbufsize)
 {
-#ifdef USE_MPI
     assert(s_count * size_ == recvbufsize);
     int count   = s_count;
     int mpi_err = MPI_Allgather(
@@ -994,15 +859,11 @@ int MGmol_MPI::allGather(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGatherImages(
     std::vector<double>& sendbuf, std::vector<double>& recvbuf)
 {
-#ifdef USE_MPI
     assert(comm_images_ != MPI_COMM_NULL);
     assert(sendbuf.size() * nimages_ == recvbuf.size());
     int count   = (int)sendbuf.size();
@@ -1015,15 +876,11 @@ int MGmol_MPI::allGatherImages(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGatherImages(
     std::vector<int>& sendbuf, std::vector<int>& recvbuf)
 {
-#ifdef USE_MPI
     assert(comm_images_ != MPI_COMM_NULL);
     if (sendbuf.size() * nimages_ != recvbuf.size())
     {
@@ -1041,15 +898,11 @@ int MGmol_MPI::allGatherImages(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGatherImages(
     std::vector<short>& sendbuf, std::vector<short>& recvbuf)
 {
-#ifdef USE_MPI
     assert(comm_images_ != MPI_COMM_NULL);
     if (sendbuf.size() * nimages_ != recvbuf.size())
     {
@@ -1067,15 +920,11 @@ int MGmol_MPI::allGatherImages(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGatherV(
     std::vector<double>& sendbuf, std::vector<double>& recvbuf)
 {
-#ifdef USE_MPI
     int sendcount   = (int)sendbuf.size();
     int* recvcounts = new int[size_];
     int mpi_err     = MPI_Allgather(
@@ -1106,15 +955,11 @@ int MGmol_MPI::allGatherV(
     delete[] recvcounts;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGatherV(
     std::vector<float>& sendbuf, std::vector<float>& recvbuf)
 {
-#ifdef USE_MPI
     int sendcount   = (int)sendbuf.size();
     int* recvcounts = new int[size_];
     int mpi_err     = MPI_Allgather(
@@ -1145,14 +990,10 @@ int MGmol_MPI::allGatherV(
     delete[] recvcounts;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGatherV(std::vector<int>& sendbuf, std::vector<int>& recvbuf)
 {
-#ifdef USE_MPI
     int sendcount   = (int)sendbuf.size();
     int* recvcounts = new int[size_];
     int mpi_err     = MPI_Allgather(
@@ -1183,15 +1024,11 @@ int MGmol_MPI::allGatherV(std::vector<int>& sendbuf, std::vector<int>& recvbuf)
     delete[] recvcounts;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGatherV(
     std::vector<short>& sendbuf, std::vector<short>& recvbuf)
 {
-#ifdef USE_MPI
     int sendcount   = (int)sendbuf.size();
     int* recvcounts = new int[size_];
     int mpi_err     = MPI_Allgather(
@@ -1222,15 +1059,11 @@ int MGmol_MPI::allGatherV(
     delete[] recvcounts;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGatherV(
     std::vector<unsigned short>& sendbuf, std::vector<unsigned short>& recvbuf)
 {
-#ifdef USE_MPI
     int sendcount   = (int)sendbuf.size();
     int* recvcounts = new int[size_];
     int mpi_err     = MPI_Allgather(
@@ -1261,15 +1094,11 @@ int MGmol_MPI::allGatherV(
     delete[] recvcounts;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::allGatherV(
     std::vector<std::string>& sendbuf, std::vector<std::string>& recvbuf)
 {
-#ifdef USE_MPI
     ////
     int vcount = (int)sendbuf.size();
     allreduce(&vcount, 1, MPI_SUM);
@@ -1343,9 +1172,6 @@ int MGmol_MPI::allGatherV(
     delete[] recvdata;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::gatherV(
@@ -1369,7 +1195,6 @@ int MGmol_MPI::gatherV(
 int MGmol_MPI::scatter(
     double* sendbuf, int sendbufsize, double* recvbuf, int count, int root)
 {
-#ifdef USE_MPI
     assert(count * size_ == sendbufsize);
     int mpi_err = MPI_Scatter(sendbuf, count, MPI_DOUBLE, recvbuf, count,
         MPI_DOUBLE, root, comm_spin_);
@@ -1379,15 +1204,11 @@ int MGmol_MPI::scatter(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::scatter(
     float* sendbuf, int sendbufsize, float* recvbuf, int count, int root)
 {
-#ifdef USE_MPI
     assert(count * size_ == sendbufsize);
     int mpi_err = MPI_Scatter(
         sendbuf, count, MPI_FLOAT, recvbuf, count, MPI_FLOAT, root, comm_spin_);
@@ -1397,15 +1218,11 @@ int MGmol_MPI::scatter(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int MGmol_MPI::scatter(
     int* sendbuf, int sendbufsize, int* recvbuf, int count, int root)
 {
-#ifdef USE_MPI
     assert(count * size_ == sendbufsize);
     int mpi_err = MPI_Scatter(
         sendbuf, count, MPI_INT, recvbuf, count, MPI_INT, root, comm_spin_);
@@ -1415,12 +1232,7 @@ int MGmol_MPI::scatter(
     }
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
-
-#ifdef USE_MPI
 
 void MGmol_MPI::split_allreduce_sums_float(float* array, const int nelements)
 {
@@ -1592,23 +1404,3 @@ void MGmol_MPI::split_allreduce_sums_short(
 
     delete[] work_short;
 }
-
-#else
-
-void MGmol_MPI::split_allreduce_sums_double(double* array, const int nelements)
-{
-    return;
-}
-
-void MGmol_MPI::split_allreduce_sums_int(int* array, const int nelements)
-{
-    return;
-}
-
-void MGmol_MPI::split_allreduce_sums_short(
-    short int* array, const int nelements)
-{
-    return;
-}
-
-#endif

--- a/src/tools/MGmol_MPI.h
+++ b/src/tools/MGmol_MPI.h
@@ -13,9 +13,7 @@
 
 #include "Timer.h"
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include <cassert>
 #include <cstring>
@@ -123,12 +121,7 @@ public:
 
     int size() const { return size_; }
 
-    void barrier() const
-    {
-#ifdef USE_MPI
-        MPI_Barrier(comm_global_);
-#endif
-    }
+    void barrier() const { MPI_Barrier(comm_global_); }
     int bcast(std::string& common_string, MPI_Comm comm) const;
     int bcast(short* val, int size = 1, int root = 0) const;
     int bcast(int* val, int size = 1, int root = 0) const;

--- a/src/tools/MPIdata.cc
+++ b/src/tools/MPIdata.cc
@@ -12,9 +12,7 @@
 
 #include "MPIdata.h"
 
-#ifdef USE_MPI
 int MPIdata::mype; // rank of this process
 bool MPIdata::onpe0;
 std::ostream* MPIdata::sout = &std::cout; // default value
 std::ostream* MPIdata::serr = &std::cerr; // default value
-#endif

--- a/src/tools/MPIdata.h
+++ b/src/tools/MPIdata.h
@@ -13,8 +13,6 @@
 #ifndef MPIDATA_H
 #define MPIDATA_H
 
-#ifdef USE_MPI
-
 #include <fstream>
 #include <iostream>
 #include <mpi.h>
@@ -26,16 +24,5 @@ extern std::ostream* sout;
 extern std::ostream* serr;
 }
 using namespace MPIdata;
-
-#else
-
-const int mype     = 0;
-const bool onpe0   = true;
-std::ostream* sout = &std::cout;
-std::ostream* serr = &std::cerr;
-
-typedef int MPI_Comm;
-
-#endif
 
 #endif

--- a/src/tools/SymmetricMatrix.cc
+++ b/src/tools/SymmetricMatrix.cc
@@ -13,35 +13,29 @@
 template <>
 void SymmetricMatrix<short>::mpiAllOr()
 {
-#ifdef USE_MPI
     short* recvbuf = new short[size_];
     MPI_Allreduce(&data_[0], recvbuf, size_, MPI_SHORT, MPI_BOR, comm_);
     memcpy(&data_[0], recvbuf, size_ * sizeof(short));
 
     delete[] recvbuf;
-#endif
 }
 
 template <>
 void SymmetricMatrix<char>::mpiAllOr()
 {
-#ifdef USE_MPI
     char* recvbuf = new char[size_];
     MPI_Allreduce(&data_[0], recvbuf, size_, MPI_CHAR, MPI_BOR, comm_);
     memcpy(&data_[0], recvbuf, size_ * sizeof(char));
 
     delete[] recvbuf;
-#endif
 }
 
 template <>
 void SymmetricMatrix<int>::mpiAllOr()
 {
-#ifdef USE_MPI
     int* recvbuf = new int[size_];
     MPI_Allreduce(&data_[0], recvbuf, size_, MPI_INT, MPI_BOR, comm_);
     memcpy(&data_[0], recvbuf, size_ * sizeof(int));
 
     delete[] recvbuf;
-#endif
 }

--- a/src/tools/Timeout.h
+++ b/src/tools/Timeout.h
@@ -28,9 +28,7 @@ extern "C" int pcssig_register(int signal, time_t mintime, int* status);
 void sighandler(int sig);
 #endif
 
-#if USE_MPI
 #include "MPIdata.h"
-#endif
 
 class Timeout
 {

--- a/src/tools/Vector3D.cc
+++ b/src/tools/Vector3D.cc
@@ -68,8 +68,7 @@ Vector3D Vector3D::vminimage(
 
 void bcastvv3d(std::vector<Vector3D>& vv, MPI_Comm comm)
 {
-#ifdef USE_MPI
-    const int n    = vv.size();
+    const int n    = (int)vv.size();
     double* buffer = new double[3 * n];
     for (int j = 0; j < n; j++)
         for (short i = 0; i < 3; i++)
@@ -90,5 +89,4 @@ void bcastvv3d(std::vector<Vector3D>& vv, MPI_Comm comm)
             vv[j].x_[i] = buffer[3 * j + i];
         }
     delete[] buffer;
-#endif
 }

--- a/src/tools/Vector3D.h
+++ b/src/tools/Vector3D.h
@@ -226,12 +226,7 @@ public:
         return is;
     }
 
-    void bcast(MPI_Comm comm)
-    {
-#ifdef USE_MPI
-        MPI_Bcast(&x_[0], 3, MPI_DOUBLE, 0, comm);
-#endif
-    }
+    void bcast(MPI_Comm comm) { MPI_Bcast(&x_[0], 3, MPI_DOUBLE, 0, comm); }
 
     friend void bcastvv3d(std::vector<Vector3D>& vv, MPI_Comm comm);
 };

--- a/src/tools/mgmol_mpi_tools.cc
+++ b/src/tools/mgmol_mpi_tools.cc
@@ -20,7 +20,6 @@ namespace mgmol_tools
 int reduce(int* sendbuf, int* recvbuf, int count, MPI_Op op, const int root,
     const MPI_Comm comm)
 {
-#ifdef USE_MPI
     assert(comm != 0);
     int mpi_err = MPI_Reduce(sendbuf, recvbuf, count, MPI_INT, op, root, comm);
     if (mpi_err != MPI_SUCCESS)
@@ -29,18 +28,13 @@ int reduce(int* sendbuf, int* recvbuf, int count, MPI_Op op, const int root,
                   << "!!!" << std::endl;
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int reduce(int* buf, int count, MPI_Op op, const int root, const MPI_Comm comm)
 {
     int mype = 0;
-#ifdef USE_MPI
     assert(comm != 0);
     MPI_Comm_rank(comm, &mype);
-#endif
 
     int* recvbuf = new int[count];
     int ret      = reduce(buf, recvbuf, count, op, root, comm);
@@ -54,7 +48,6 @@ int reduce(int* buf, int count, MPI_Op op, const int root, const MPI_Comm comm)
 int reduce(double* sendbuf, double* recvbuf, int count, MPI_Op op,
     const int root, const MPI_Comm comm)
 {
-#ifdef USE_MPI
     assert(comm != 0);
     int mpi_err
         = MPI_Reduce(sendbuf, recvbuf, count, MPI_DOUBLE, op, root, comm);
@@ -64,15 +57,11 @@ int reduce(double* sendbuf, double* recvbuf, int count, MPI_Op op,
                   << "!!!" << std::endl;
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int reduce(float* sendbuf, float* recvbuf, int count, MPI_Op op, const int root,
     const MPI_Comm comm)
 {
-#ifdef USE_MPI
     assert(comm != 0);
     int mpi_err
         = MPI_Reduce(sendbuf, recvbuf, count, MPI_FLOAT, op, root, comm);
@@ -82,15 +71,11 @@ int reduce(float* sendbuf, float* recvbuf, int count, MPI_Op op, const int root,
                   << "!!!" << std::endl;
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int reduce(short* sendbuf, short* recvbuf, int count, MPI_Op op, const int root,
     const MPI_Comm comm)
 {
-#ifdef USE_MPI
     assert(comm != 0);
     int mpi_err
         = MPI_Reduce(sendbuf, recvbuf, count, MPI_SHORT, op, root, comm);
@@ -100,9 +85,6 @@ int reduce(short* sendbuf, short* recvbuf, int count, MPI_Op op, const int root,
                   << "!!!" << std::endl;
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int gatherV(std::vector<std::string>& sendbuf,
@@ -110,7 +92,6 @@ int gatherV(std::vector<std::string>& sendbuf,
 {
     int mype = 0;
     int size = 1;
-#ifdef USE_MPI
     assert(comm != 0);
     MPI_Comm_rank(comm, &mype);
     MPI_Comm_size(comm, &size);
@@ -192,15 +173,11 @@ int gatherV(std::vector<std::string>& sendbuf,
     delete[] recvdata;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int gatherV(std::vector<int>& sendbuf, std::vector<int>& recvbuf,
     const int root, const MPI_Comm comm)
 {
-#ifdef USE_MPI
     int mype = 0;
     int size = 1;
     MPI_Comm_rank(comm, &mype);
@@ -238,15 +215,11 @@ int gatherV(std::vector<int>& sendbuf, std::vector<int>& recvbuf,
     delete[] recvcounts;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int gatherV(std::vector<unsigned short>& sendbuf,
     std::vector<unsigned short>& recvbuf, const int root, const MPI_Comm comm)
 {
-#ifdef USE_MPI
     int mype = 0;
     int size = 1;
     MPI_Comm_rank(comm, &mype);
@@ -285,15 +258,11 @@ int gatherV(std::vector<unsigned short>& sendbuf,
     delete[] recvcounts;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int gatherV(std::vector<double>& sendbuf, std::vector<double>& recvbuf,
     const int root, const MPI_Comm comm)
 {
-#ifdef USE_MPI
     int mype = 0;
     int size = 1;
     MPI_Comm_rank(comm, &mype);
@@ -332,15 +301,11 @@ int gatherV(std::vector<double>& sendbuf, std::vector<double>& recvbuf,
     delete[] recvcounts;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int gatherV(std::vector<float>& sendbuf, std::vector<float>& recvbuf,
     const int root, const MPI_Comm comm)
 {
-#ifdef USE_MPI
     int mype = 0;
     int size = 1;
     MPI_Comm_rank(comm, &mype);
@@ -379,15 +344,11 @@ int gatherV(std::vector<float>& sendbuf, std::vector<float>& recvbuf,
     delete[] recvcounts;
 
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 
 int allreduce(
     short* sendbuf, short* recvbuf, int count, MPI_Op op, const MPI_Comm comm)
 {
-#ifdef USE_MPI
     int mpi_err = MPI_Allreduce(sendbuf, recvbuf, count, MPI_SHORT, op, comm);
     if (mpi_err != MPI_SUCCESS)
     {
@@ -395,8 +356,5 @@ int allreduce(
                   << "!!!" << std::endl;
     }
     return mpi_err;
-#else
-    return 0;
-#endif
 }
 }

--- a/src/unused/KBPsiMatrix.h
+++ b/src/unused/KBPsiMatrix.h
@@ -89,9 +89,7 @@ class KBPsiMatrix : public KBPsiMatrixInterface
         ptr_kbBpsi_[gid][st] += val;
     }
 
-#ifdef USE_MPI
     void allGatherNonzeroElements(MPI_Comm comm, const int ntasks);
-#endif
 
     void clear();
 


### PR DESCRIPTION
The build system requires MPI so the `USE_MPI` is always defined. This PR remove the macro and all the dead code.