### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: "-*,clang-analyzer-deadcode*,clang-analyzer-nullability*,clang-analyzer-unix*,clang-analyzer-core*,clang-analyzer-cplusplus*,clang-analyzer-optin*,performance-*,bugprone-*,modernize-use-nullptr*,modernize-use-override*,mpi*"
+
+WarningsAsErrors: '*'

--- a/src/ABPG.cc
+++ b/src/ABPG.cc
@@ -139,7 +139,7 @@ void ABPG<T>::update_states(T& orbitals, T& res, T& work_orbitals,
     {
         res.scal(alpha);
         // Extrapolation scheme
-        assert(wf_mix_ != 0);
+        assert(wf_mix_ != nullptr);
         ostream os(nullptr);
         if (onpe0) os.rdbuf(cout.rdbuf());
         wf_mix_->update(res, work_orbitals, os, (ct.verbose > 0));

--- a/src/AOMMprojector.cc
+++ b/src/AOMMprojector.cc
@@ -91,8 +91,8 @@ void AOMMprojector::resetProjectors(LocGridOrbitals& phi)
 
 void AOMMprojector::projectOut(LocGridOrbitals& phi)
 {
-    assert(kernelprojector_ != 0);
-    assert(matrix_mask_ != 0);
+    assert(kernelprojector_ != nullptr);
+    assert(matrix_mask_ != nullptr);
 
     // if( counter_%10==0 )resetProjectors(phi);
 
@@ -103,7 +103,7 @@ void AOMMprojector::projectOut(LocGridOrbitals& phi)
 
 AOMMprojector::~AOMMprojector()
 {
-    assert(kernel_phi_ != 0);
+    assert(kernel_phi_ != nullptr);
 
     delete kernelprojector_;
     kernelprojector_ = nullptr;

--- a/src/AndersonMix.cc
+++ b/src/AndersonMix.cc
@@ -53,9 +53,9 @@ template <class T>
 AndersonMix<T>::~AndersonMix()
 {
     for (int i = 0; i < m_; i++)
-        assert(xi_[i] != 0);
+        assert(xi_[i] != nullptr);
     for (int i = 0; i < m_; i++)
-        assert(fi_[i] != 0);
+        assert(fi_[i] != nullptr);
 
     for (int i = 0; i < m_; i++)
         delete xi_[i];
@@ -88,7 +88,7 @@ void AndersonMix<T>::update(T& f, T& work, ostream& os, const bool verbose)
         for (int i = 0; i < mm_; i++)
         {
             work.assign(f);
-            assert(fi_[i] != 0);
+            assert(fi_[i] != nullptr);
             work -= (*fi_[i]);
 
             mat_[i * m_ + i] = work.dotProduct(work);
@@ -293,11 +293,11 @@ void AndersonMix<T>::update(T& f, T& work, ostream& os, const bool verbose)
         }
 
         // update fi_ for next step
-        assert(fi_[m_ - 1] != 0);
+        assert(fi_[m_ - 1] != nullptr);
         T* tf = fi_[m_ - 1];
         for (int j = m_ - 1; j > 0; j--)
         {
-            assert(fi_[j - 1] != 0);
+            assert(fi_[j - 1] != nullptr);
             fi_[j] = fi_[j - 1];
         }
         fi_[0] = tf;

--- a/src/BasicDataDistributors.cc
+++ b/src/BasicDataDistributors.cc
@@ -48,9 +48,9 @@ void BasicDataDistributors::initialize(
     double spread_sH             = 3. * (*lrs).max_radii();
     double inverse_spread_radius = (*lrs).max_radii();
 
-    assert(gramMatrixDistributor_ == 0);
-    assert(centeredOrbitalsOverlapDistributor_ == 0);
-    assert(orbitalsProdWithHDistributor_ == 0);
+    assert(gramMatrixDistributor_ == nullptr);
+    assert(centeredOrbitalsOverlapDistributor_ == nullptr);
+    assert(orbitalsProdWithHDistributor_ == nullptr);
 
     gramMatrixDistributor_
         = new DataDistribution("gram", ct.spread_radius, myPEenv, domain);

--- a/src/BlockVector.cc
+++ b/src/BlockVector.cc
@@ -112,7 +112,7 @@ template <typename T>
 void BlockVector<T>::allocate_storage()
 {
     assert(size_storage_ > 0);
-    assert(storage_ == 0);
+    assert(storage_ == nullptr);
 
     Control& ct                  = *(Control::instance());
     static short high_water_mark = 0;
@@ -181,12 +181,12 @@ void BlockVector<T>::allocate_storage()
         ct.global_exit(0);
     }
     storage_ = class_storage_[my_allocation_];
-    assert(storage_ != 0);
+    assert(storage_ != nullptr);
 #else
     storage_ = new T[size_storage_];
 #endif
 
-    assert(storage_ != 0);
+    assert(storage_ != nullptr);
     assert(class_storage_.size() > 0);
 }
 
@@ -196,7 +196,7 @@ void BlockVector<T>::deallocate_storage()
 {
     if (my_allocation_ >= 0)
     {
-        assert(storage_ != 0);
+        assert(storage_ != nullptr);
 #ifdef NEWSTORAGE
         assert(my_allocation_ >= 0);
         allocated_[my_allocation_] = 0;
@@ -296,7 +296,7 @@ template <typename T>
 void BlockVector<T>::initialize(
     const vector<vector<int>>& gid, const bool skinny_stencil)
 {
-    assert(storage_ == 0);
+    assert(storage_ == nullptr);
 
     int nbvect = (int)gid[0].size();
 
@@ -334,8 +334,8 @@ double BlockVector<T>::dot(const int i, const int j, const short iloc) const
     assert(i < static_cast<int>(vect_.size()));
     assert(j < static_cast<int>(vect_.size()));
     assert(iloc < subdivx_);
-    assert(vect_[i] != 0);
-    assert(vect_[j] != 0);
+    assert(vect_[i] != nullptr);
+    assert(vect_[j] != nullptr);
 
     const int shift = iloc * locnumel_;
     return MPdot(locnumel_, vect_[i] + shift, vect_[j] + shift);
@@ -344,14 +344,14 @@ template <typename T>
 void BlockVector<T>::scal(const int i, const double alpha)
 {
     assert(i < static_cast<int>(vect_.size()));
-    assert(vect_[i] != 0);
+    assert(vect_[i] != nullptr);
 
     MPscal(ld_, alpha, vect_[i]);
 }
 template <typename T>
 void BlockVector<T>::scal(const double alpha)
 {
-    assert(storage_ != 0);
+    assert(storage_ != nullptr);
 
     MPscal(size_storage_, alpha, storage_);
 }
@@ -359,7 +359,7 @@ template <typename T>
 void BlockVector<T>::scal(const double alpha, const int i, const short iloc)
 {
     assert(static_cast<unsigned int>(i) < vect_.size());
-    assert(vect_[i] != 0);
+    assert(vect_[i] != nullptr);
 
     const int shift = iloc * locnumel_;
     MPscal(locnumel_, alpha, vect_[i] + shift);
@@ -370,8 +370,8 @@ void BlockVector<T>::axpy(
 {
     assert(static_cast<unsigned int>(ix) < vect_.size());
     assert(static_cast<unsigned int>(iy) < vect_.size());
-    assert(vect_[ix] != 0);
-    assert(vect_[iy] != 0);
+    assert(vect_[ix] != nullptr);
+    assert(vect_[iy] != nullptr);
     assert(vect_[ix] != vect_[iy]);
 
     const int shift = iloc * locnumel_;
@@ -411,7 +411,7 @@ template <typename T>
 template <typename T2>
 void BlockVector<T>::setDataWithGhosts(pb::GridFuncVector<T2>* data_wghosts)
 {
-    assert(data_wghosts != 0);
+    assert(data_wghosts != nullptr);
 
     set_data_tm_.start();
 

--- a/src/ConstraintSet.cc
+++ b/src/ConstraintSet.cc
@@ -146,7 +146,7 @@ bool ConstraintSet::addConstraint(Ions& ions, const vector<string>& argv)
         for (int i = 0; i < (int)vconstraints_.size(); i++)
         {
             Constraint* pc = vconstraints_[i];
-            assert(pc != 0);
+            assert(pc != nullptr);
             // check if a constraint (name1,name2) or (name2,name1) is defined
             if (pc->type() == "distance"
                 && ((pc->names(0) == name1 && pc->names(1) == name2)

--- a/src/DMStrategyFactory.h
+++ b/src/DMStrategyFactory.h
@@ -34,7 +34,7 @@ public:
     {
         Control& ct = *(Control::instance());
 
-        DMStrategy* dm_strategy;
+        DMStrategy* dm_strategy = nullptr;
         if (ct.DM_solver() == DMNonLinearSolverType::MVP)
         {
             dm_strategy = new MVP_DMStrategy<T>(comm, os, ions, rho, energy,

--- a/src/DensityMatrix.cc
+++ b/src/DensityMatrix.cc
@@ -104,9 +104,9 @@ DensityMatrix::~DensityMatrix()
 {
     if (dim_ > 0)
     {
-        assert(dm_ != 0);
-        assert(kernel4dot_ != 0);
-        assert(work_ != 0);
+        assert(dm_ != nullptr);
+        assert(kernel4dot_ != nullptr);
+        assert(work_ != nullptr);
 
         delete dm_;
         delete kernel4dot_;
@@ -158,7 +158,7 @@ void DensityMatrix::build(const dist_matrix::DistMatrix<DISTMATDTYPE>& zmat,
 void DensityMatrix::build(
     const vector<DISTMATDTYPE>& occ, const int new_orbitals_index)
 {
-    assert(dm_ != 0);
+    assert(dm_ != nullptr);
 
     setOccupations(occ);
 

--- a/src/DensityMatrixSparse.cc
+++ b/src/DensityMatrixSparse.cc
@@ -40,7 +40,7 @@ DensityMatrixSparse::~DensityMatrixSparse()
 {
     if (dim_ > 0)
     {
-        assert(dm_ != 0);
+        assert(dm_ != nullptr);
         delete dm_;
     }
 }
@@ -99,7 +99,7 @@ void DensityMatrixSparse::assembleMatrixFromCenteredData(
 double DensityMatrixSparse::getTraceDotProductWithMat(
     VariableSizeMatrix<sparserow>* vsmat)
 {
-    assert(dm_ != 0);
+    assert(dm_ != nullptr);
     //   assert(dm_->n() != 0);
     /* compute trace */
     double trace = 0.0;
@@ -118,7 +118,7 @@ double DensityMatrixSparse::getTraceDotProductWithMat(
 /* print a few rows of the density matrix */
 void DensityMatrixSparse::printDM(ostream& os, int nrows) const
 {
-    assert(dm_ != 0);
+    assert(dm_ != nullptr);
     //  assert( dm_->n() > 0);
 
     (*dm_).print(os, locfcns_, nrows);
@@ -129,7 +129,7 @@ void DensityMatrixSparse::printDM(ostream& os, int nrows) const
 void DensityMatrixSparse::getLocalMatrix(
     LocalMatrices<MATDTYPE>& localX, const vector<vector<int>>& global_indexes)
 {
-    assert(dm_ != 0);
+    assert(dm_ != nullptr);
 
     const short subdiv           = (short)global_indexes.size();
     const short chromatic_number = (short)global_indexes[0].size();

--- a/src/DistMatrix/BlacsContext.cc
+++ b/src/DistMatrix/BlacsContext.cc
@@ -325,8 +325,8 @@ BlacsContext::BlacsContext(BlacsContext& bc, const int irow, const int icol,
 BlacsContext::BlacsContext(const BlacsContext& bc, const char type)
     : ictxt_(-1), myrow_(-1), mycol_(-1), comm_global_(bc.comm_global_)
 {
-    mype_ = bc.mype_;
-    int* pmap;
+    mype_     = bc.mype_;
+    int* pmap = nullptr;
     if (type == 'c')
     {
         // make context consisting of my column in context bc

--- a/src/DistMatrix/DistMatrix.cc
+++ b/src/DistMatrix/DistMatrix.cc
@@ -48,7 +48,7 @@ DistMatrix<T>::DistMatrix(const std::string& name)
       mb_(0),
       nb_(0)
 {
-    assert(default_bc_ != 0);
+    assert(default_bc_ != nullptr);
 }
 
 template <class T>
@@ -2581,7 +2581,7 @@ float DistMatrix<float>::getVal(const int i, const int j) const
 
     float val;
     if (active_) pselget(&scope, &top, &val, val_.data(), &ia, &ja, desc_);
-    MPI_Bcast(&val, 1, MPI_DOUBLE, 0, comm_global_);
+    MPI_Bcast(&val, 1, MPI_FLOAT, 0, comm_global_);
     return val;
 }
 
@@ -2596,7 +2596,7 @@ double DistMatrix<double>::getVal(const int i, const int j) const
 
     double val;
     if (active_) pdelget(&scope, &top, &val, val_.data(), &ia, &ja, desc_);
-    MPI_Bcast(&val, 1, MPI_FLOAT, 0, comm_global_);
+    MPI_Bcast(&val, 1, MPI_DOUBLE, 0, comm_global_);
     return val;
 }
 

--- a/src/DistMatrix/SparseDistMatrix.cc
+++ b/src/DistMatrix/SparseDistMatrix.cc
@@ -866,7 +866,7 @@ void SparseDistMatrix<double>::parallelSumToDistMatrix()
     // if( my_task_index_==0 )cout<<"parallelSumToDistMatrix() using
     // ZOLTAN"<<endl;
 
-    assert(&mat_ != NULL);
+    assert(&mat_ != nullptr);
 #ifdef DEBUG
     print(cout);
 #endif
@@ -961,7 +961,7 @@ void SparseDistMatrix<float>::parallelSumToDistMatrix()
     // if( my_task_index_==0 )cout<<"parallelSumToDistMatrix() using
     // ZOLTAN"<<endl;
 
-    assert(&mat_ != NULL);
+    assert(&mat_ != nullptr);
 #ifdef DEBUG
     print(cout);
 #endif
@@ -1457,7 +1457,7 @@ void SparseDistMatrix<float>::sendRecvData()
 template <class T>
 void SparseDistMatrix<T>::parallelSumToDistMatrix1()
 {
-    assert(&mat_ != NULL);
+    assert(&mat_ != nullptr);
 #ifdef DEBUG
     print(cout);
 #endif
@@ -1475,7 +1475,7 @@ void SparseDistMatrix<T>::parallelSumToDistMatrix1()
 TEMP_DECL
 void SparseDistMatrix<double>::parallelSumToDistMatrix2()
 {
-    assert(&mat_ != NULL);
+    assert(&mat_ != nullptr);
     assert(npartitions_ >= 0);
     assert(npartitions_ <= npes_);
 #ifdef DEBUG
@@ -1590,7 +1590,7 @@ void SparseDistMatrix<double>::parallelSumToDistMatrix2()
 TEMP_DECL
 void SparseDistMatrix<float>::parallelSumToDistMatrix2()
 {
-    assert(&mat_ != NULL);
+    assert(&mat_ != nullptr);
     assert(npartitions_ >= 0);
     assert(npartitions_ <= npes_);
 #ifdef DEBUG

--- a/src/DistanceConstraint.cc
+++ b/src/DistanceConstraint.cc
@@ -71,13 +71,13 @@ void DistanceConstraint::setup(const vector<string>& names,
 
     if (locally_active_)
     {
-        assert(tau1_ != 0);
-        assert(tau1p_ != 0);
-        assert(fion1_ != 0);
+        assert(tau1_ != nullptr);
+        assert(tau1p_ != nullptr);
+        assert(fion1_ != nullptr);
         assert(m1_ > 0.0);
-        assert(tau2_ != 0);
-        assert(tau2p_ != 0);
-        assert(fion2_ != 0);
+        assert(tau2_ != nullptr);
+        assert(tau2p_ != nullptr);
+        assert(fion2_ != nullptr);
         assert(tau1p_ != tau2p_);
         assert(m2_ > 0.0);
     }

--- a/src/Electrostatic.cc
+++ b/src/Electrostatic.cc
@@ -189,7 +189,7 @@ void Electrostatic::setupInitialVh(const pb::GridFunc<POTDTYPE>& vh_init)
 template <class T>
 void Electrostatic::computeVhRho(Rho<T>& rho)
 {
-    assert(grhoc_ != NULL);
+    assert(grhoc_ != nullptr);
 
     Mesh* mymesh = Mesh::instance();
 
@@ -212,7 +212,7 @@ void Electrostatic::computeVhRho(Rho<T>& rho)
     Evh_rho_  = poisson_solver_->IntVhRho();
     Evh_rhoc_ = poisson_solver_->IntVhRhoc();
 
-    if (vrho.size() > 1) delete work_rho;
+    if (vrho.size() > 1) delete[] work_rho;
 
     iterative_index_ = rho.getIterativeIndex();
 }
@@ -221,7 +221,7 @@ void Electrostatic::setupPB(
     const double rho0, const double drho0, Potentials& pot)
 {
     assert(rho0 > 0.);
-    assert(grhod_ == NULL);
+    assert(grhod_ == nullptr);
 
     Mesh* mymesh    = Mesh::instance();
     const double e0 = 78.36;
@@ -329,7 +329,7 @@ void Electrostatic::setupPB(
 
 void Electrostatic::fillFuncAroundIons(const Ions& ions)
 {
-    assert(grhod_ != NULL);
+    assert(grhod_ != nullptr);
     assert(diel_flag_);
 
     const short shift = pbGrid_->ghost_pt();
@@ -454,7 +454,7 @@ void Electrostatic::computeVh(const Ions& ions, Rho<T>& rho, Potentials& pot)
     if (onpe0) (*MPIdata::sout) << "Electrostatic::computeVh()" << endl;
 #endif
 
-    assert(grhoc_ != NULL);
+    assert(grhoc_ != nullptr);
 
     Mesh* mymesh             = Mesh::instance();
     const pb::PEenv& myPEenv = mymesh->peenv();
@@ -507,7 +507,7 @@ void Electrostatic::computeVh(const Ions& ions, Rho<T>& rho, Potentials& pot)
     Evh_rhoc_   = poisson_solver_->IntVhRhoc();
     Evhold_rho_ = poisson_solver_->IntVhRho_old();
 
-    if (vrho.size() > 1) delete work;
+    if (vrho.size() > 1) delete[] work;
 
     solve_tm_.stop();
 }

--- a/src/EnergySpreadPenalty.cc
+++ b/src/EnergySpreadPenalty.cc
@@ -18,7 +18,7 @@ using namespace std;
 template <class T>
 void EnergySpreadPenalty<T>::addResidual(T& phi, T& res)
 {
-    assert(spreadf_ != 0);
+    assert(spreadf_ != nullptr);
     assert(spread2_target_ >= 0.);
 
     // compute data to be used to evaluate spreads and centers
@@ -199,7 +199,7 @@ void EnergySpreadPenalty<T>::computeAndAddResidualSpreadPenalty(
 template <class T>
 double EnergySpreadPenalty<T>::evaluateEnergy(const T& phi)
 {
-    assert(spreadf_ != 0);
+    assert(spreadf_ != nullptr);
     assert(spread2_target_ >= 0.);
 
     // compute data to be used to evaluate spreads and centers

--- a/src/ExtendedGridOrbitals.cc
+++ b/src/ExtendedGridOrbitals.cc
@@ -77,7 +77,7 @@ ExtendedGridOrbitals::ExtendedGridOrbitals(std::string name,
 
     // preconditions
     assert(subdivx > 0);
-    assert(proj_matrices != 0);
+    assert(proj_matrices != nullptr);
 
     for (short i = 0; i < 3; i++)
         assert(bc[i] == 0 || bc[i] == 1);
@@ -94,7 +94,10 @@ ExtendedGridOrbitals::ExtendedGridOrbitals(std::string name,
     if (setup_flag) setup();
 }
 
-ExtendedGridOrbitals::~ExtendedGridOrbitals() { assert(proj_matrices_ != 0); }
+ExtendedGridOrbitals::~ExtendedGridOrbitals()
+{
+    assert(proj_matrices_ != nullptr);
+}
 
 ExtendedGridOrbitals::ExtendedGridOrbitals(const std::string& name,
     const ExtendedGridOrbitals& A, const bool copy_data)
@@ -107,7 +110,7 @@ ExtendedGridOrbitals::ExtendedGridOrbitals(const std::string& name,
     // if(onpe0)cout<<"call ExtendedGridOrbitals(const ExtendedGridOrbitals &A,
     // const bool copy_data)"<<endl;
 
-    assert(A.proj_matrices_ != 0);
+    assert(A.proj_matrices_ != nullptr);
 }
 
 ExtendedGridOrbitals::ExtendedGridOrbitals(const std::string& name,
@@ -119,7 +122,7 @@ ExtendedGridOrbitals::ExtendedGridOrbitals(const std::string& name,
       block_vector_(A.block_vector_, copy_data),
       grid_(A.grid_)
 {
-    assert(proj_matrices != 0);
+    assert(proj_matrices != nullptr);
 
     // setup new projected_matrices object
     Control& ct = *(Control::instance());
@@ -128,7 +131,7 @@ ExtendedGridOrbitals::ExtendedGridOrbitals(const std::string& name,
 
 void ExtendedGridOrbitals::copyDataFrom(const ExtendedGridOrbitals& src)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     block_vector_.copyDataFrom(src.block_vector_);
 
@@ -152,7 +155,7 @@ void ExtendedGridOrbitals::setup()
     Control& ct = *(Control::instance());
 
     // preconditions
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     if (ct.verbose > 0)
         printWithTimeStamp(
@@ -528,7 +531,7 @@ void ExtendedGridOrbitals::multiply_by_matrix(
 
 int ExtendedGridOrbitals::read_hdf5(HDFrestart& h5f_file)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     Control& ct = *(Control::instance());
 
@@ -566,9 +569,10 @@ int ExtendedGridOrbitals::read_hdf5(HDFrestart& h5f_file)
     return ierr;
 }
 
-int ExtendedGridOrbitals::write_hdf5(HDFrestart& h5f_file, std::string name)
+int ExtendedGridOrbitals::write_hdf5(
+    HDFrestart& h5f_file, const std::string& name)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
     Control& ct = *(Control::instance());
 
     if (!ct.fullyOccupied())
@@ -580,7 +584,7 @@ int ExtendedGridOrbitals::write_hdf5(HDFrestart& h5f_file, std::string name)
         if (ierr < 0) return ierr;
     }
 
-    int ierr = write_func_hdf5(h5f_file, std::move(name));
+    int ierr = write_func_hdf5(h5f_file, name);
 
     return ierr;
 }
@@ -832,7 +836,7 @@ void ExtendedGridOrbitals::computeMatB(
 {
     if (numst_ == 0) return;
 
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     matB_tm_.start();
 #if DEBUG
@@ -889,7 +893,7 @@ void ExtendedGridOrbitals::computeMatB(
 // compute <Phi|B|Phi> and its inverse
 void ExtendedGridOrbitals::computeBAndInvB(const pb::Lap<ORBDTYPE>& LapOper)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     Control& ct = *(Control::instance());
     if (!ct.Mehrstellen()) return;
@@ -957,7 +961,7 @@ void ExtendedGridOrbitals::computeLocalProduct(const ORBDTYPE* const array,
 {
     assert(loc_numpt_ > 0);
     assert(loc_numpt_ <= ld);
-    assert(array != 0);
+    assert(array != nullptr);
     assert(numst_ != 0);
     assert(grid_.vel() > 0.);
     assert(subdivx_ > 0);
@@ -1011,7 +1015,7 @@ void ExtendedGridOrbitals::computeDiagonalElementsDotProduct(
 void ExtendedGridOrbitals::computeGram(
     dist_matrix::DistMatrix<DISTMATDTYPE>& gram_mat)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, numst_);
 
@@ -1025,7 +1029,7 @@ void ExtendedGridOrbitals::computeGram(
 void ExtendedGridOrbitals::computeGram(const ExtendedGridOrbitals& orbitals,
     dist_matrix::DistMatrix<DISTMATDTYPE>& gram_mat)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, numst_);
 
@@ -1040,7 +1044,7 @@ void ExtendedGridOrbitals::computeGram(const ExtendedGridOrbitals& orbitals,
 // compute the lower-triangular part of the overlap matrix
 void ExtendedGridOrbitals::computeGram(const int verbosity)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     overlap_tm_.start();
 
@@ -1066,7 +1070,7 @@ void ExtendedGridOrbitals::computeGram(const int verbosity)
 
 void ExtendedGridOrbitals::computeGramAndInvS(const int verbosity)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     computeGram(verbosity);
 
@@ -1076,7 +1080,7 @@ void ExtendedGridOrbitals::computeGramAndInvS(const int verbosity)
 
 void ExtendedGridOrbitals::checkCond(const double tol, const bool flag_stop)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     proj_matrices_->checkCond(tol, flag_stop);
 }
@@ -1084,7 +1088,7 @@ void ExtendedGridOrbitals::checkCond(const double tol, const bool flag_stop)
 double ExtendedGridOrbitals::dotProductWithDM(
     const ExtendedGridOrbitals& orbitals)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, numst_);
 
@@ -1096,7 +1100,7 @@ double ExtendedGridOrbitals::dotProductWithDM(
 double ExtendedGridOrbitals::dotProductWithInvS(
     const ExtendedGridOrbitals& orbitals)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, numst_);
 
@@ -1108,7 +1112,7 @@ double ExtendedGridOrbitals::dotProductWithInvS(
 double ExtendedGridOrbitals::dotProductDiagonal(
     const ExtendedGridOrbitals& orbitals)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     std::vector<DISTMATDTYPE> ss(numst_);
     computeDiagonalElementsDotProduct(orbitals, ss);
@@ -1119,7 +1123,7 @@ double ExtendedGridOrbitals::dotProductDiagonal(
 double ExtendedGridOrbitals::dotProductSimple(
     const ExtendedGridOrbitals& orbitals)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, numst_);
 

--- a/src/ExtendedGridOrbitals.h
+++ b/src/ExtendedGridOrbitals.h
@@ -360,7 +360,7 @@ public:
     void multiplyByMatrix2states(const int st1, const int st2,
         const double* mat, ExtendedGridOrbitals& product);
 
-    int write_hdf5(HDFrestart& h5f_file, std::string name = "Function");
+    int write_hdf5(HDFrestart& h5f_file, const std::string& name = "Function");
     int write_func_hdf5(HDFrestart&, const std::string& name = "Function");
     int read_hdf5(HDFrestart& h5f_file);
     int read_func_hdf5(HDFrestart&, const std::string& name = "Function");

--- a/src/Forces.cc
+++ b/src/Forces.cc
@@ -388,7 +388,7 @@ void Forces<T>::lforce(Ions& ions, RHODTYPE* rho)
         // Forces opposed to the gradient
         int index   = lion->index();
         int* rindex = (int*)loc_proj_mat.getTableValue(index);
-        assert(rindex != NULL);
+        assert(rindex != nullptr);
         std::fill(loc_proj.begin(), loc_proj.end(), 0.);
         loc_proj_mat.row_daxpy(
             *rindex, buffer_size, mygrid.vel(), &loc_proj[0]);

--- a/src/FullyOccupiedNonOrthoDMStrategy.cc
+++ b/src/FullyOccupiedNonOrthoDMStrategy.cc
@@ -21,7 +21,7 @@ void FullyOccupiedNonOrthoDMStrategy::initialize() { update(); }
 
 int FullyOccupiedNonOrthoDMStrategy::update()
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     proj_matrices_->setDMto2InvS();
 

--- a/src/GramMatrix.cc
+++ b/src/GramMatrix.cc
@@ -178,7 +178,7 @@ void GramMatrix::rotateAll(const dist_matrix::DistMatrix<DISTMATDTYPE>& matU)
 void GramMatrix::setMatrix(
     const dist_matrix::DistMatrix<DISTMATDTYPE>& mat, const int orbitals_index)
 {
-    assert(matS_ != 0);
+    assert(matS_ != nullptr);
 
     *matS_          = mat;
     orbitals_index_ = orbitals_index;

--- a/src/HDFrestart.cc
+++ b/src/HDFrestart.cc
@@ -1485,8 +1485,8 @@ int HDFrestart::read_1func_hdf5(float* vv, const std::string& datasetname)
 int HDFrestart::write_1func_hdf5(
     double* vv, const std::string& datasetname, double* ll, double* cell_origin)
 {
-    assert(ll != NULL);
-    assert(cell_origin != NULL);
+    assert(ll != nullptr);
+    assert(cell_origin != nullptr);
 
     Control& ct = *(Control::instance());
     if (onpe0 && ct.verbose > 0)
@@ -1583,8 +1583,8 @@ int HDFrestart::write_1func_hdf5(
 int HDFrestart::write_1func_hdf5(
     float* vv, const string& datasetname, double* ll, double* cell_origin)
 {
-    assert(ll != NULL);
-    assert(cell_origin != NULL);
+    assert(ll != nullptr);
+    assert(cell_origin != nullptr);
 
     if (onpe0)
         (*MPIdata::sout) << "HDFrestart::write_1func_hdf5(). Try to write data "
@@ -1881,7 +1881,7 @@ int HDFrestart::writeData(double* data, hid_t space_id, hid_t memspace,
     }
     else
     {
-        assert(work_space_double_ != 0);
+        assert(work_space_double_ != nullptr);
         memcpy(work_space_double_, data, bsize_ * sizeof(double));
     }
     // gather data on active PEs
@@ -1974,7 +1974,7 @@ int HDFrestart::writeData(double* data, hid_t space_id, hid_t memspace,
         }
 
         // Close/release resources.
-        if (use_hdf5p_ && pes_.n_mpi_tasks() > 1) status = H5Pclose(plist_id);
+        if (use_hdf5p_ && pes_.n_mpi_tasks() > 1) H5Pclose(plist_id);
     }
 
     return 0;
@@ -2055,7 +2055,7 @@ int HDFrestart::writeData(float* data, hid_t space_id, hid_t memspace,
         }
 
         // Close/release resources.
-        if (use_hdf5p_ && pes_.n_mpi_tasks() > 1) status = H5Pclose(plist_id);
+        if (use_hdf5p_ && pes_.n_mpi_tasks() > 1) H5Pclose(plist_id);
     }
 
     return 0;
@@ -2103,11 +2103,11 @@ void HDFrestart::setCommActive()
 {
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     int mytask      = 0;
-    int mpirc       = MPI_Comm_rank(mmpi.commSameSpin(), &mytask);
+    MPI_Comm_rank(mmpi.commSameSpin(), &mytask);
     if (gather_data_x_)
     {
         int color = (int)active_;
-        mpirc
+        int mpirc
             = MPI_Comm_split(mmpi.commSameSpin(), color, mytask, &comm_active_);
         if (mpirc != MPI_SUCCESS)
         {
@@ -3105,14 +3105,14 @@ void HDFrestart::gatherDataXdir(vector<FixedLengthString>& data)
         {
             assert(active_);
             int datasize = data.size();
-            char* buffer = new char[datasize * IonData_MaxStrLength];
+            std::vector<char> buffer(datasize * IonData_MaxStrLength);
             for (int i = 0; i < datasize; i++)
                 memcpy(&buffer[i * IonData_MaxStrLength], &data[i],
                     IonData_MaxStrLength);
 
             MPI_Send(&datasize, 1, MPI_INT, dest, 2 * tag, comm_data_);
-            MPI_Send(buffer, datasize * IonData_MaxStrLength, MPI_CHAR, dest,
-                2 * tag + 1, comm_data_);
+            MPI_Send(buffer.data(), datasize * IonData_MaxStrLength, MPI_CHAR,
+                dest, 2 * tag + 1, comm_data_);
         }
         else if (pes_.my_mpi(0) == i)
         {
@@ -3120,9 +3120,9 @@ void HDFrestart::gatherDataXdir(vector<FixedLengthString>& data)
             int datasize;
             MPI_Recv(
                 &datasize, 1, MPI_INT, source, 2 * tag, comm_data_, &mpistatus);
-            char* buffer = new char[datasize * IonData_MaxStrLength];
-            MPI_Recv(buffer, datasize * IonData_MaxStrLength, MPI_CHAR, source,
-                2 * tag + 1, comm_data_, &mpistatus);
+            std::vector<char> buffer(datasize * IonData_MaxStrLength);
+            MPI_Recv(buffer.data(), datasize * IonData_MaxStrLength, MPI_CHAR,
+                source, 2 * tag + 1, comm_data_, &mpistatus);
             data.resize(datasize);
             for (int i = 0; i < datasize; i++)
                 memcpy(&data[i], &buffer[i * IonData_MaxStrLength],

--- a/src/HamiltonianMVPSolver.cc
+++ b/src/HamiltonianMVPSolver.cc
@@ -81,7 +81,7 @@ int HamiltonianMVPSolver<T1, T2, T3, T4>::solve(T4& orbitals)
 {
     Control& ct = *(Control::instance());
 
-    assert(numst_ = (int)orbitals.numst());
+    assert(numst_ == (int)orbitals.numst());
     assert(n_inner_steps_ > 0);
 
     solve_tm_.start();

--- a/src/HamiltonianMVP_DMStrategy.cc
+++ b/src/HamiltonianMVP_DMStrategy.cc
@@ -37,8 +37,8 @@ HamiltonianMVP_DMStrategy<T1, T2, T3, T4>::HamiltonianMVP_DMStrategy(
 {
     Control& ct = *(Control::instance());
 
-    assert(electrostat_ != 0);
-    assert(energy_ != 0);
+    assert(electrostat_ != nullptr);
+    assert(energy_ != nullptr);
     assert(ct.dm_inner_steps > 0);
 
     T3* projmatrices = dynamic_cast<T3*>(orbitals->getProjMatrices());
@@ -63,7 +63,7 @@ void HamiltonianMVP_DMStrategy<T1, T2, T3, T4>::initialize()
 template <class T1, class T2, class T3, class T4>
 int HamiltonianMVP_DMStrategy<T1, T2, T3, T4>::update()
 {
-    assert(solver_ != 0);
+    assert(solver_ != nullptr);
 
     Control& ct = *(Control::instance());
     if (onpe0 && ct.verbose > 2)

--- a/src/Ions.cc
+++ b/src/Ions.cc
@@ -2215,7 +2215,7 @@ int Ions::readNatoms(const std::string& filename, const bool cell_relative)
 int Ions::readNatoms(std::ifstream* tfile, const bool cell_relative)
 {
     MGmol_MPI& mmpi(*(MGmol_MPI::instance()));
-    if (mmpi.PE0()) assert(tfile != 0);
+    if (mmpi.PE0()) assert(tfile != nullptr);
 
     // set pointer to species object
     // set up list boundaries
@@ -2689,8 +2689,6 @@ double Ions::computeMaxNLprojRadius() const
 void Ions::gatherNames(std::map<int, std::string>& names, const int root,
     const MPI_Comm comm) const
 {
-    assert(comm != 0);
-
     std::vector<int> indexes(num_ions_, 0);
     std::vector<int> local_indexes;
     std::vector<std::string> data;
@@ -2713,9 +2711,9 @@ void Ions::gatherNames(std::map<int, std::string>& names, const int root,
     MPI_Comm_rank(comm, &mype);
     if (mype == root)
     {
-        int num_ions = data.size();
-        assert(num_ions = indexes.size());
-        for (int i = 0; i < num_ions; i++)
+        const unsigned int num_ions = data.size();
+        assert(num_ions == indexes.size());
+        for (unsigned int i = 0; i < num_ions; i++)
         {
             const int ion_index        = indexes[i];
             const std::string ion_name = data[i];
@@ -2727,8 +2725,6 @@ void Ions::gatherNames(std::map<int, std::string>& names, const int root,
 void Ions::gatherNames(
     std::vector<std::string>& names, const int root, const MPI_Comm comm) const
 {
-    assert(comm != 0);
-
     std::vector<std::string> local_names;
 
     std::vector<Ion*>::const_iterator ion = local_ions_.begin();
@@ -2817,8 +2813,6 @@ void Ions::gatherNLprojIds(
 void Ions::gatherAtomicNumbers(
     std::vector<int>& atnumbers, const int root, const MPI_Comm comm) const
 {
-    assert(comm != 0);
-
     std::vector<int> local_atnumbers;
 
     std::vector<Ion*>::const_iterator ion = local_ions_.begin();

--- a/src/KBPsiMatrixSparse.cc
+++ b/src/KBPsiMatrixSparse.cc
@@ -78,8 +78,8 @@ void KBPsiMatrixSparse::setup(const Ions& ions, const T& orbitals)
     // number of projectors overlapping with subdomain
     count_proj_subdomain_ = ions.countProjectorsSubdomain();
     /* setup matrices */
-    assert(kbpsimat_ == 0);
-    assert(kbBpsimat_ == 0);
+    assert(kbpsimat_ == nullptr);
+    assert(kbBpsimat_ == nullptr);
     kbpsimat_
         = new VariableSizeMatrix<sparserow>("KBpsi", count_proj_subdomain_);
     if (lapop_)
@@ -99,7 +99,7 @@ void KBPsiMatrixSparse::setup(const Ions& ions, const T& orbitals)
     //        "<<spread_radius_<<endl;
 
     /* construct data distribution object */
-    assert(distributor_ == 0);
+    assert(distributor_ == nullptr);
     Mesh* mymesh             = Mesh::instance();
     const pb::Grid& mygrid   = mymesh->grid();
     const pb::PEenv& myPEenv = mymesh->peenv();
@@ -154,7 +154,7 @@ void KBPsiMatrixSparse::computeKBpsi(Ions& ions, T& orbitals,
 
     if (flag)
     {
-        assert(lapop_ != NULL);
+        assert(lapop_ != nullptr);
         ppsi = new ORBDTYPE[nb_colors * ldsize];
         orbitals.setDataWithGhosts();
         orbitals.trade_boundaries();
@@ -210,7 +210,7 @@ void KBPsiMatrixSparse::computeKBpsi(Ions& ions, T& orbitals,
 void KBPsiMatrixSparse::computeKBpsi(
     Ions& ions, pb::GridFunc<ORBDTYPE>* phi, const int istate, const bool flag)
 {
-    assert(lapop_ != NULL);
+    assert(lapop_ != nullptr);
     compute_kbpsi_tm_.start();
 
     Mesh* mymesh           = Mesh::instance();
@@ -380,7 +380,7 @@ void KBPsiMatrixSparse::computeHvnlMatrix(const KBPsiMatrixSparse* const kbpsi2,
     const Ion& ion, ProjectedMatricesInterface* proj_matrices) const
 {
     assert(ion.here());
-    assert(proj_matrices != 0);
+    assert(proj_matrices != nullptr);
 
     vector<int> gids;
     ion.getGidsNLprojs(gids);

--- a/src/KBprojectorSparse.h
+++ b/src/KBprojectorSparse.h
@@ -121,7 +121,7 @@ public:
     KBprojectorSparse(const Species& sp);
     KBprojectorSparse(const KBprojectorSparse& kbp);
 
-    ~KBprojectorSparse() { clear(); }
+    virtual ~KBprojectorSparse() { clear(); }
 
     void clear() override
     {

--- a/src/LDAFunctional.cc
+++ b/src/LDAFunctional.cc
@@ -39,9 +39,9 @@ void LDAFunctional::computeXC(void)
 {
     if (nspin_ == 1)
     {
-        assert(prho_ != 0);
-        assert(pexc_ != 0);
-        assert(pvxc1_ != 0);
+        assert(prho_ != nullptr);
+        assert(pexc_ != nullptr);
+        assert(pvxc1_ != nullptr);
         for (int ir = 0; ir < np_; ir++)
         {
             xc_unpolarized(prho_[ir], pexc_[ir], pvxc1_[ir]);
@@ -50,11 +50,11 @@ void LDAFunctional::computeXC(void)
     else
     {
         // spin polarized
-        assert(prho_up_ != 0);
-        assert(prho_dn_ != 0);
-        assert(pexc_ != 0);
-        assert(pvxc1_up_ != 0);
-        assert(pvxc1_dn_ != 0);
+        assert(prho_up_ != nullptr);
+        assert(prho_dn_ != nullptr);
+        assert(pexc_ != nullptr);
+        assert(pvxc1_up_ != nullptr);
+        assert(pvxc1_dn_ != nullptr);
         const double fz_prefac  = 1.0 / (cbrt(2.0) * 2.0 - 2.0);
         const double dfz_prefac = (fourthird)*fz_prefac;
         for (int ir = 0; ir < np_; ir++)

--- a/src/LocGridOrbitals.cc
+++ b/src/LocGridOrbitals.cc
@@ -81,8 +81,8 @@ LocGridOrbitals::LocGridOrbitals(std::string name, const pb::Grid& my_grid,
 {
     // preconditions
     assert(subdivx > 0);
-    assert(proj_matrices != 0);
-    assert(lrs != 0);
+    assert(proj_matrices != nullptr);
+    assert(lrs != nullptr);
 
     for (short i = 0; i < 3; i++)
         assert(bc[i] == 0 || bc[i] == 1);
@@ -111,9 +111,9 @@ LocGridOrbitals::LocGridOrbitals(std::string name, const pb::Grid& my_grid,
 
 LocGridOrbitals::~LocGridOrbitals()
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
     assert(pack_);
-    assert(gidToStorage_ != 0);
+    assert(gidToStorage_ != nullptr);
 
     // delete gidToStorage here. This is OK since it is not a shared data
     // else there would be a memory leak.
@@ -136,8 +136,8 @@ LocGridOrbitals::LocGridOrbitals(
     // copy_data)"<<endl;
 
     assert(A.chromatic_number_ >= 0);
-    assert(A.proj_matrices_ != 0);
-    assert(A.lrs_ != 0);
+    assert(A.proj_matrices_ != nullptr);
+    assert(A.lrs_ != nullptr);
 
     copySharedData(A);
 
@@ -158,9 +158,9 @@ LocGridOrbitals::LocGridOrbitals(const std::string& name,
       lrs_(A.lrs_)
 {
     assert(A.chromatic_number_ >= 0);
-    assert(proj_matrices != 0);
-    assert(masks != 0);
-    assert(lrs_ != 0);
+    assert(proj_matrices != nullptr);
+    assert(masks != nullptr);
+    assert(lrs_ != nullptr);
 
     copySharedData(A);
 
@@ -181,7 +181,7 @@ void LocGridOrbitals::copySharedData(const LocGridOrbitals& A)
     // if(onpe0)cout<<"call LocGridOrbitals::copySharedData(const
     // LocGridOrbitals &A)"<<endl;
 
-    assert(A.gidToStorage_ != 0);
+    assert(A.gidToStorage_ != nullptr);
     assert(A.pack_);
 
     numst_ = A.numst_;
@@ -202,7 +202,7 @@ void LocGridOrbitals::copySharedData(const LocGridOrbitals& A)
 
 void LocGridOrbitals::copyDataFrom(const LocGridOrbitals& src)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     block_vector_.copyDataFrom(src.block_vector_);
 
@@ -265,7 +265,7 @@ const ORBDTYPE* LocGridOrbitals::getGidStorage(
 void LocGridOrbitals::setup(
     MasksSet* masks, MasksSet* corrmasks, LocalizationRegions* lrs)
 {
-    assert(masks != 0);
+    assert(masks != nullptr);
     Control& ct = *(Control::instance());
     if (ct.verbose > 0)
         printWithTimeStamp("LocGridOrbitals::setup(MasksSet*, MasksSet*)...",
@@ -282,8 +282,8 @@ void LocGridOrbitals::setup(LocalizationRegions* lrs)
     Control& ct = *(Control::instance());
 
     // preconditions
-    assert(lrs != 0);
-    assert(proj_matrices_ != 0);
+    assert(lrs != nullptr);
+    assert(proj_matrices_ != nullptr);
 
     if (ct.verbose > 0)
         printWithTimeStamp("LocGridOrbitals::setup()...", (*MPIdata::sout));
@@ -340,7 +340,7 @@ void LocGridOrbitals::assign(const LocGridOrbitals& orbitals)
     mmpi.barrier();
 #endif
     assert(chromatic_number_ >= 0);
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     setIterativeIndex(orbitals);
 
@@ -387,8 +387,8 @@ void LocGridOrbitals::axpy(const double alpha, const LocGridOrbitals& orbitals)
 {
     axpy_tm_.start();
 
-    assert(pack_ != 0);
-    assert(orbitals.pack_ != 0);
+    assert(pack_ != nullptr);
+    assert(orbitals.pack_ != nullptr);
     assert(overlapping_gids_.size() > 0);
 
     //    int ione=1;
@@ -695,7 +695,7 @@ void LocGridOrbitals::initFourier()
 
 int LocGridOrbitals::packStates(LocalizationRegions* lrs)
 {
-    assert(lrs != 0);
+    assert(lrs != nullptr);
 
     Control& ct = *(Control::instance());
 
@@ -914,7 +914,7 @@ void LocGridOrbitals::multiply_by_matrix(
 
 int LocGridOrbitals::read_hdf5(HDFrestart& h5f_file)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     Control& ct = *(Control::instance());
 
@@ -948,9 +948,9 @@ int LocGridOrbitals::read_hdf5(HDFrestart& h5f_file)
     return ierr;
 }
 
-int LocGridOrbitals::write_hdf5(HDFrestart& h5f_file, string name)
+int LocGridOrbitals::write_hdf5(HDFrestart& h5f_file, const string& name)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
     Control& ct = *(Control::instance());
 
     if (!ct.fullyOccupied())
@@ -962,7 +962,7 @@ int LocGridOrbitals::write_hdf5(HDFrestart& h5f_file, string name)
         if (ierr < 0) return ierr;
     }
 
-    int ierr = write_func_hdf5(h5f_file, std::move(name));
+    int ierr = write_func_hdf5(h5f_file, name);
 
     return ierr;
 }
@@ -1384,7 +1384,7 @@ void LocGridOrbitals::computeMatB(
 {
     if (numst_ == 0) return;
 
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     matB_tm_.start();
 #if DEBUG
@@ -1440,7 +1440,7 @@ void LocGridOrbitals::computeMatB(
 // compute <Phi|B|Phi> and its inverse
 void LocGridOrbitals::computeBAndInvB(const pb::Lap<ORBDTYPE>& LapOper)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     Control& ct = *(Control::instance());
     if (!ct.Mehrstellen()) return;
@@ -1507,7 +1507,7 @@ void LocGridOrbitals::computeLocalProduct(const ORBDTYPE* const array,
 {
     assert(loc_numpt_ > 0);
     assert(loc_numpt_ <= ld);
-    assert(array != 0);
+    assert(array != nullptr);
     assert(chromatic_number_ != 0);
     assert(grid_.vel() > 0.);
     assert(subdivx_ > 0);
@@ -1611,7 +1611,7 @@ void LocGridOrbitals::computeDiagonalElementsDotProductLocal(
 void LocGridOrbitals::computeGram(
     dist_matrix::DistMatrix<DISTMATDTYPE>& gram_mat)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, chromatic_number_);
 
@@ -1625,7 +1625,7 @@ void LocGridOrbitals::computeGram(
 void LocGridOrbitals::computeGram(const LocGridOrbitals& orbitals,
     dist_matrix::DistMatrix<DISTMATDTYPE>& gram_mat)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, chromatic_number_);
 
@@ -1640,7 +1640,7 @@ void LocGridOrbitals::computeGram(const LocGridOrbitals& orbitals,
 // compute the lower-triangular part of the overlap matrix
 void LocGridOrbitals::computeGram(const int verbosity)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     // if( chromatic_number_==0 )return;
 
@@ -1667,7 +1667,7 @@ void LocGridOrbitals::computeGram(const int verbosity)
 
 void LocGridOrbitals::computeGramAndInvS(const int verbosity)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     computeGram(verbosity);
 
@@ -1677,14 +1677,14 @@ void LocGridOrbitals::computeGramAndInvS(const int verbosity)
 
 void LocGridOrbitals::checkCond(const double tol, const bool flag_stop)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     proj_matrices_->checkCond(tol, flag_stop);
 }
 
 double LocGridOrbitals::dotProductWithDM(const LocGridOrbitals& orbitals)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
     assert(chromatic_number_ == orbitals.chromatic_number_);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, chromatic_number_);
@@ -1696,7 +1696,7 @@ double LocGridOrbitals::dotProductWithDM(const LocGridOrbitals& orbitals)
 
 double LocGridOrbitals::dotProductWithInvS(const LocGridOrbitals& orbitals)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
     assert(chromatic_number_ == orbitals.chromatic_number_);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, chromatic_number_);
@@ -1708,7 +1708,7 @@ double LocGridOrbitals::dotProductWithInvS(const LocGridOrbitals& orbitals)
 
 double LocGridOrbitals::dotProductDiagonal(const LocGridOrbitals& orbitals)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
     //(*MPIdata::sout)<<"call LocGridOrbitals::dotProductDiagonal()..."<<endl;
 
     vector<DISTMATDTYPE> ss;
@@ -1727,7 +1727,7 @@ double LocGridOrbitals::dotProductDiagonal(const LocGridOrbitals& orbitals)
 
 double LocGridOrbitals::dotProductSimple(const LocGridOrbitals& orbitals)
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
     assert(chromatic_number_ == orbitals.chromatic_number_);
 
     SquareLocalMatrices<MATDTYPE> ss(subdivx_, chromatic_number_);

--- a/src/LocGridOrbitals.h
+++ b/src/LocGridOrbitals.h
@@ -405,7 +405,7 @@ public:
     void multiplyByMatrix2states(const int st1, const int st2,
         const double* mat, LocGridOrbitals& product);
 
-    int write_hdf5(HDFrestart& h5f_file, std::string name = "Function");
+    int write_hdf5(HDFrestart& h5f_file, const std::string& name = "Function");
     int write_func_hdf5(HDFrestart&, const std::string& name = "Function");
     int read_hdf5(HDFrestart& h5f_file);
     int read_func_hdf5(HDFrestart&, const std::string& name = "Function");

--- a/src/MGmol.cc
+++ b/src/MGmol.cc
@@ -366,7 +366,7 @@ int MGmol<T>::initial()
     if (ct.verbose > 0) printWithTimeStamp("Initialize XC functional...", os_);
     xcongrid_
         = XCfunctionalFactory<T>::create(ct.xctype, mmpi.nspin(), *rho_, pot);
-    assert(xcongrid_ != 0);
+    assert(xcongrid_ != nullptr);
 
     // initialize nl potentials with restart values if possible
     //    if( ct.restart_info>1 )
@@ -546,7 +546,7 @@ void MGmol<T>::printMM()
         std::ofstream tfileh("h.mm", std::ios::out);
         ProjectedMatrices* projmatrices
             = dynamic_cast<ProjectedMatrices*>(proj_matrices_);
-        assert(projmatrices != 0);
+        assert(projmatrices != nullptr);
         projmatrices->printHamiltonianMM(tfileh);
     }
 }
@@ -1059,7 +1059,7 @@ void MGmol<T>::cleanup()
 template <>
 void MGmol<LocGridOrbitals>::projectOutKernel(LocGridOrbitals& phi)
 {
-    assert(aomm_ != 0);
+    assert(aomm_ != nullptr);
     aomm_->projectOut(phi);
 }
 
@@ -1074,7 +1074,7 @@ void MGmol<T>::projectOutKernel(T& phi)
 template <class T>
 void MGmol<T>::setGamma(const pb::Lap<ORBDTYPE>& lapOper, const Potentials& pot)
 {
-    assert(orbitals_precond_ != 0);
+    assert(orbitals_precond_ != nullptr);
 
     Control& ct = *(Control::instance());
 
@@ -1084,7 +1084,7 @@ void MGmol<T>::setGamma(const pb::Lap<ORBDTYPE>& lapOper, const Potentials& pot)
 template <class T>
 void MGmol<T>::precond_mg(T& phi)
 {
-    assert(orbitals_precond_ != 0);
+    assert(orbitals_precond_ != nullptr);
 
     orbitals_precond_->precond_mg(phi);
 }
@@ -1312,7 +1312,7 @@ void MGmol<T>::update_pot(const Ions& ions)
 template <class T>
 void MGmol<T>::addResidualSpreadPenalty(T& phi, T& res)
 {
-    assert(spread_penalty_ != 0);
+    assert(spread_penalty_ != nullptr);
 
     spread_penalty_->addResidual(phi, res);
 }

--- a/src/MVPSolver.cc
+++ b/src/MVPSolver.cc
@@ -161,7 +161,7 @@ int MVPSolver<T>::solve(T& orbitals)
 {
     Control& ct = *(Control::instance());
 
-    assert(numst_ = (int)orbitals.numst());
+    assert(numst_ == (int)orbitals.numst());
     assert(n_inner_steps_ > 0);
 
     solve_tm_.start();

--- a/src/MVP_DMStrategy.cc
+++ b/src/MVP_DMStrategy.cc
@@ -37,8 +37,8 @@ MVP_DMStrategy<T>::MVP_DMStrategy(MPI_Comm comm, ostream& os, Ions& ions,
       mgmol_strategy_(mgmol_strategy),
       use_old_dm_(use_old_dm)
 {
-    assert(electrostat_ != 0);
-    assert(energy_ != 0);
+    assert(electrostat_ != nullptr);
+    assert(energy_ != nullptr);
 }
 
 template <class T>

--- a/src/Masks4Orbitals.cc
+++ b/src/Masks4Orbitals.cc
@@ -39,7 +39,7 @@ void Masks4Orbitals::associateGids2Masks(const vector<int>& overlap_gids)
     {
         int gid         = (*it);
         GridMask* maski = masks_->get_pmask(gid);
-        assert(maski != 0);
+        assert(maski != nullptr);
         gid_to_mask_.insert(pair<int, GridMask*>(gid, maski));
     }
 
@@ -49,7 +49,7 @@ void Masks4Orbitals::associateGids2Masks(const vector<int>& overlap_gids)
         {
             int gid          = (*it);
             GridMask* maskci = corrmasks_->get_pmask(gid);
-            assert(maskci != 0);
+            assert(maskci != nullptr);
             gid_to_corrmask_.insert(pair<int, GridMask*>(gid, maskci));
         }
 
@@ -69,8 +69,8 @@ short Masks4Orbitals::checkOverlap(
 
     GridMask* gm1 = it1->second;
     GridMask* gm2 = it2->second;
-    assert(gm1 != 0);
-    assert(gm2 != 0);
+    assert(gm1 != nullptr);
+    assert(gm2 != nullptr);
 
     return gm1->overlap_on_pe(*gm2, level);
 }

--- a/src/MultiDistanceConstraint.cc
+++ b/src/MultiDistanceConstraint.cc
@@ -137,12 +137,12 @@ void MultiDistanceConstraint::setup(const vector<string>& names_known_locally,
     if (locally_active_)
         for (int i = 0; i < nc; i++)
         {
-            assert(m_tau1_[i] != NULL);
-            assert(m_tau2_[i] != NULL);
-            assert(m_tau1p_[i] != NULL);
-            assert(m_tau2p_[i] != NULL);
-            assert(m_fion1_[i] != NULL);
-            assert(m_fion2_[i] != NULL);
+            assert(m_tau1_[i] != nullptr);
+            assert(m_tau2_[i] != nullptr);
+            assert(m_tau1p_[i] != nullptr);
+            assert(m_tau2p_[i] != nullptr);
+            assert(m_fion1_[i] != nullptr);
+            assert(m_fion2_[i] != nullptr);
         }
 
     short lactive = (short)locally_active_;

--- a/src/NOLMOTransform.cc
+++ b/src/NOLMOTransform.cc
@@ -780,7 +780,7 @@ void NOLMOTransform::gatherTransformMat()
     std::vector<DISTMATDTYPE> sendbuf(nst_ * nloc);
     if (a_->active()) a_->copyDataToVector(sendbuf);
     DISTMATDTYPE* recvbuf = &mat_[0];
-    assert(recvbuf != NULL);
+    assert(recvbuf != nullptr);
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     MPI_Comm comm   = mmpi.commSameSpin();
     MPI_Allgatherv(&sendbuf[0], nst_ * nloc, MPI_DOUBLE, recvbuf,

--- a/src/NonOrthoDMStrategy.cc
+++ b/src/NonOrthoDMStrategy.cc
@@ -38,7 +38,7 @@ void NonOrthoDMStrategy<T>::initialize()
 template <class T>
 int NonOrthoDMStrategy<T>::update()
 {
-    assert(proj_matrices_ != 0);
+    assert(proj_matrices_ != nullptr);
 
     Control& ct = *(Control::instance());
     if (onpe0 && ct.verbose > 2)

--- a/src/OrbitalsExtrapolation.cc
+++ b/src/OrbitalsExtrapolation.cc
@@ -23,7 +23,14 @@ using namespace std;
 template <class T>
 OrbitalsExtrapolation<T>::~OrbitalsExtrapolation()
 {
-    clearOldOrbitals();
+    if (orbitals_minus1_ != nullptr)
+    {
+        delete orbitals_minus1_;
+        orbitals_minus1_ = nullptr;
+    }
+#if EXTRAPOLATE_H
+    delete hextrapol_;
+#endif
 }
 
 template <class T>

--- a/src/OrbitalsPreconditioning.cc
+++ b/src/OrbitalsPreconditioning.cc
@@ -24,7 +24,7 @@ template <class T>
 OrbitalsPreconditioning<T>::~OrbitalsPreconditioning()
 {
     assert(is_set_);
-    assert(precond_ != 0);
+    assert(precond_ != nullptr);
 
     delete precond_;
     if (gfv_work_ != nullptr)
@@ -59,7 +59,7 @@ void OrbitalsPreconditioning<T>::setup(T& orbitals, const short mg_levels,
     {
         int gid         = (*it);
         GridMask* maski = currentMasks->get_pmask(gid);
-        assert(maski != 0);
+        assert(maski != nullptr);
         gid_to_mask.insert(std::pair<int, GridMask*>(gid, maski));
     }
     precond_->setup(gid_to_mask, orbitals.getOverlappingGids());
@@ -94,7 +94,7 @@ template <class T>
 void OrbitalsPreconditioning<T>::precond_mg(T& orbitals)
 {
     assert(is_set_);
-    assert(precond_ != 0);
+    assert(precond_ != nullptr);
     assert(gamma_ > 0.);
 
 #ifdef PRINT_OPERATIONS
@@ -131,7 +131,7 @@ void OrbitalsPreconditioning<T>::precond_mg(T& orbitals)
     else
     {
         // block-implemented preconditioner
-        assert(gfv_work_ != 0);
+        assert(gfv_work_ != nullptr);
 
         gfv_work_->resetData();
 
@@ -154,7 +154,7 @@ void OrbitalsPreconditioning<T>::setGamma(const pb::Lap<ORBDTYPE>& lapOper,
     const Potentials& pot, const short mg_levels,
     ProjectedMatricesInterface* proj_matrices)
 {
-    assert(precond_ != 0);
+    assert(precond_ != nullptr);
     assert(is_set_);
 
     const double small_eig = proj_matrices->getLowestEigenvalue();

--- a/src/PBEFunctional.cc
+++ b/src/PBEFunctional.cc
@@ -80,11 +80,12 @@ void PBEFunctional::computeXC(void)
 {
     if (nspin_ == 1)
     {
-        assert(prho_ != 0);
-        assert(pgrad_rho_[0] != 0 && pgrad_rho_[1] != 0 && pgrad_rho_[2] != 0);
-        assert(pexc_ != 0);
-        assert(pvxc1_ != 0);
-        assert(pvxc2_ != 0);
+        assert(prho_ != nullptr);
+        assert(pgrad_rho_[0] != nullptr && pgrad_rho_[1] != nullptr
+               && pgrad_rho_[2] != nullptr);
+        assert(pexc_ != nullptr);
+        assert(pvxc1_ != nullptr);
+        assert(pvxc2_ != nullptr);
 
         const RHODTYPE* const grad0 = pgrad_rho_[0];
         const RHODTYPE* const grad1 = pgrad_rho_[1];
@@ -106,20 +107,20 @@ void PBEFunctional::computeXC(void)
     }
     else
     {
-        assert(prho_up_ != 0);
-        assert(prho_dn_ != 0);
-        assert(pgrad_rho_up_[0] != 0 && pgrad_rho_up_[1] != 0
-               && pgrad_rho_up_[2] != 0);
-        assert(pgrad_rho_dn_[0] != 0 && pgrad_rho_dn_[1] != 0
-               && pgrad_rho_dn_[2] != 0);
-        assert(pexc_up_ != 0);
-        assert(pexc_dn_ != 0);
-        assert(pvxc1_up_ != 0);
-        assert(pvxc1_dn_ != 0);
-        assert(pvxc2_upup_ != 0);
-        assert(pvxc2_updn_ != 0);
-        assert(pvxc2_dnup_ != 0);
-        assert(pvxc2_dndn_ != 0);
+        assert(prho_up_ != nullptr);
+        assert(prho_dn_ != nullptr);
+        assert(pgrad_rho_up_[0] != nullptr && pgrad_rho_up_[1] != nullptr
+               && pgrad_rho_up_[2] != nullptr);
+        assert(pgrad_rho_dn_[0] != nullptr && pgrad_rho_dn_[1] != nullptr
+               && pgrad_rho_dn_[2] != nullptr);
+        assert(pexc_up_ != nullptr);
+        assert(pexc_dn_ != nullptr);
+        assert(pvxc1_up_ != nullptr);
+        assert(pvxc1_dn_ != nullptr);
+        assert(pvxc2_upup_ != nullptr);
+        assert(pvxc2_updn_ != nullptr);
+        assert(pvxc2_dnup_ != nullptr);
+        assert(pvxc2_dndn_ != nullptr);
 
         for (int i = 0; i < np_; i++)
         {

--- a/src/PBEonGrid.cc
+++ b/src/PBEonGrid.cc
@@ -128,7 +128,7 @@ void PBEonGrid<T>::update()
 template <class T>
 double PBEonGrid<T>::getExc() const
 {
-    assert(pbe_ != NULL);
+    assert(pbe_ != nullptr);
 
     Mesh* mymesh           = Mesh::instance();
     const pb::Grid& mygrid = mymesh->grid();

--- a/src/PBEonGridSpin.cc
+++ b/src/PBEonGridSpin.cc
@@ -204,7 +204,7 @@ void PBEonGridSpin<T>::update()
 
     if (myspin_ == 0)
     {
-        assert(pbe_->pvxc1_up_ != 0);
+        assert(pbe_->pvxc1_up_ != nullptr);
         //        Tcopy(&np_, pbe_->pvxc1_up_, &ione, &vxc_[0], &ione);
         MPcpy(&vxc_[0], pbe_->pvxc1_up_, np_);
         gf_vsigma[0] = new pb::GridFunc<POTDTYPE>(
@@ -214,7 +214,7 @@ void PBEonGridSpin<T>::update()
     }
     else
     {
-        assert(pbe_->pvxc1_dn_ != 0);
+        assert(pbe_->pvxc1_dn_ != nullptr);
         //        Tcopy(&np_, pbe_->pvxc1_dn_, &ione, &vxc_[np_], &ione);
         MPcpy(&vxc_[np_], pbe_->pvxc1_dn_, np_);
         gf_vsigma[0] = new pb::GridFunc<POTDTYPE>(
@@ -266,7 +266,7 @@ double PBEonGridSpin<T>::getExc() const
     mmpi.allreduce(&exc, &sum, 1, MPI_SUM);
     exc = sum;
 #else
-    assert(pbe_ != NULL);
+    assert(pbe_ != nullptr);
     double exc = pbe_->computeRhoDotExc();
 #endif
     return exc * mygrid.vel();

--- a/src/PBdiel.cc
+++ b/src/PBdiel.cc
@@ -43,7 +43,7 @@ void PBdiel<T>::solve(
     // Subtract compensating charges from rho
     work_rho -= rhoc;
 
-    assert(rhod_ != NULL);
+    assert(rhod_ != nullptr);
 
     /* Check for uniform precision before calling poisson_solver.
      * Downgrade or upgrade rhs (work_rho) and rhod_ to have precision of
@@ -84,7 +84,7 @@ void PBdiel<T>::solve(
 template <class T>
 void PBdiel<T>::set_rhod(pb::GridFunc<RHODTYPE>* rhod)
 {
-    //(*MPIdata::sout)<<"set_rhod"<<std::endl;
-    assert(rhod != NULL);
+    //(*MPIdata::sout)<<"set_rhod"<<endl;
+    assert(rhod != nullptr);
     rhod_ = rhod;
 }

--- a/src/PBdiel_CG.cc
+++ b/src/PBdiel_CG.cc
@@ -29,7 +29,7 @@ void PBdiel_CG<T>::solve(
     // Subtract compensating charges from rho
     work_rho -= rhoc;
 
-    assert(rhod_ != NULL);
+    assert(rhod_ != nullptr);
 
     /* Check for uniform precision before calling poisson_solver.
      * Downgrade or upgrade rhs (work_rho) and rhod_ to have precision of
@@ -71,7 +71,7 @@ template <class T>
 void PBdiel_CG<T>::set_rhod(pb::GridFunc<RHODTYPE>* rhod)
 {
     //(*MPIdata::sout)<<"set_rhod"<<endl;
-    assert(rhod != NULL);
+    assert(rhod != nullptr);
     rhod_ = rhod;
 }
 

--- a/src/PCGSolver.cc
+++ b/src/PCGSolver.cc
@@ -23,17 +23,17 @@ void PCGSolver<T, T2>::clear()
     }
     for (short i = 0; i < (short)gf_work_.size(); i++)
     {
-        assert(gf_work_[i] != NULL);
+        assert(gf_work_[i] != nullptr);
         delete gf_work_[i];
     }
     for (short i = 0; i < (short)gf_rcoarse_.size(); i++)
     {
-        assert(gf_rcoarse_[i] != NULL);
+        assert(gf_rcoarse_[i] != nullptr);
         delete gf_rcoarse_[i];
     }
     for (short i = 0; i < (short)gf_newv_.size(); i++)
     {
-        assert(gf_newv_[i] != NULL);
+        assert(gf_newv_[i] != nullptr);
         delete gf_newv_[i];
     }
     // delete grids after pb::GridFunc<T2> objects since those

--- a/src/PCGSolver_Diel.cc
+++ b/src/PCGSolver_Diel.cc
@@ -21,17 +21,17 @@ void PCGSolver_Diel<T, T2>::clear()
     }
     for (short i = 0; i < (short)gf_work_.size(); i++)
     {
-        assert(gf_work_[i] != NULL);
+        assert(gf_work_[i] != nullptr);
         delete gf_work_[i];
     }
     for (short i = 0; i < (short)gf_rcoarse_.size(); i++)
     {
-        assert(gf_rcoarse_[i] != NULL);
+        assert(gf_rcoarse_[i] != nullptr);
         delete gf_rcoarse_[i];
     }
     for (short i = 0; i < (short)gf_newv_.size(); i++)
     {
-        assert(gf_newv_[i] != NULL);
+        assert(gf_newv_[i] != nullptr);
         delete gf_newv_[i];
     }
     // delete grids after pb::GridFunc<T2> objects since those

--- a/src/Preconditioning.cc
+++ b/src/Preconditioning.cc
@@ -55,17 +55,17 @@ void Preconditioning<T>::clear()
     }
     for (short i = 0; i < (short)gf_work_.size(); i++)
     {
-        assert(gf_work_[i] != NULL);
+        assert(gf_work_[i] != nullptr);
         delete gf_work_[i];
     }
     for (short i = 0; i < (short)gf_rcoarse_.size(); i++)
     {
-        assert(gf_rcoarse_[i] != NULL);
+        assert(gf_rcoarse_[i] != nullptr);
         delete gf_rcoarse_[i];
     }
     for (short i = 0; i < (short)gf_newv_.size(); i++)
     {
-        assert(gf_newv_[i] != NULL);
+        assert(gf_newv_[i] != nullptr);
         delete gf_newv_[i];
     }
     // delete grids after pb::GridFunc<T> objects since those
@@ -189,7 +189,7 @@ void Preconditioning<T>::mg(pb::GridFuncVector<T>& gfv_v,
 
     // restrictions
     pb::GridFuncVector<T>* rcoarse = gfv_rcoarse_[level];
-    assert(rcoarse != 0);
+    assert(rcoarse != nullptr);
     gfv_work_[level]->restrict3D(*rcoarse);
 
     // LOCALIZATION

--- a/src/ProjectedMatrices.cc
+++ b/src/ProjectedMatrices.cc
@@ -481,8 +481,8 @@ double ProjectedMatrices::computeEntropy()
     // if(onpe0)(*MPIdata::sout)<<"ProjectedMatrices::computeEntropy()"<<endl;
     // if(onpe0)(*MPIdata::sout)<<"width_="<<width_<<endl;
 
-    Control& ct = *(Control::instance());
-    double entropy;
+    Control& ct    = *(Control::instance());
+    double entropy = 0.;
 
     if (ct.DMEigensolver() == DMEigensolverType::Eigensolver
         || ct.DMEigensolver() == DMEigensolverType::SP2
@@ -896,7 +896,7 @@ void ProjectedMatrices::resetDotProductMatrices()
 double ProjectedMatrices::dotProductWithInvS(
     const SquareLocalMatrices<MATDTYPE>& local_product)
 {
-    assert(gram_4dotProducts_ != 0);
+    assert(gram_4dotProducts_ != nullptr);
 
     dist_matrix::DistMatrix<DISTMATDTYPE> ds("ds", dim_, dim_);
     LocalMatrices2DistMatrix* sl2dm = LocalMatrices2DistMatrix::instance();
@@ -926,7 +926,7 @@ double ProjectedMatrices::dotProductWithDM(
 double ProjectedMatrices::dotProductSimple(
     const SquareLocalMatrices<MATDTYPE>& local_product)
 {
-    assert(dm_4dot_product_ != 0);
+    assert(dm_4dot_product_ != nullptr);
 
     dist_matrix::DistMatrix<DISTMATDTYPE> ds("ds", dim_, dim_);
     LocalMatrices2DistMatrix* sl2dm = LocalMatrices2DistMatrix::instance();
@@ -976,7 +976,7 @@ double ProjectedMatrices::computeTraceInvSmultMat(
 double ProjectedMatrices::computeTraceInvSmultMatMultTheta(
     const dist_matrix::DistMatrix<DISTMATDTYPE>& mat)
 {
-    assert(theta_ != 0);
+    assert(theta_ != nullptr);
     dist_matrix::DistMatrix<DISTMATDTYPE> pmat("pmat", dim_, dim_);
 
     // compute mat*theta_

--- a/src/ProjectedMatricesMehrstellen.cc
+++ b/src/ProjectedMatricesMehrstellen.cc
@@ -40,8 +40,8 @@ ProjectedMatricesMehrstellen::~ProjectedMatricesMehrstellen()
 
 void ProjectedMatricesMehrstellen::computeInvB()
 {
-    assert(matB_ != 0);
-    assert(invB_ != 0);
+    assert(matB_ != nullptr);
+    assert(invB_ != nullptr);
     {
 
 #ifdef DEBUG

--- a/src/ProjectedMatricesSparse.cc
+++ b/src/ProjectedMatricesSparse.cc
@@ -48,7 +48,7 @@ Timer ProjectedMatricesSparse::eig_interval_tm_(
 ProjectedMatricesSparse::ProjectedMatricesSparse(
     const int ndim, LocalizationRegions* lrs, ClusterOrbitals* local_cluster)
 {
-    assert(lrs != 0);
+    assert(lrs != nullptr);
 
     dim_     = ndim;
     min_val_ = 0.25;
@@ -102,16 +102,16 @@ void ProjectedMatricesSparse::clearData()
 
 ProjectedMatricesSparse::~ProjectedMatricesSparse()
 {
-    assert(invS_ != 0);
-    assert(dm_ != 0);
-    assert(localX_ != 0);
-    assert(localT_ != 0);
-    assert(submatT_ != 0);
-    assert(sH_ != 0);
-    assert(matHB_ != 0);
-    assert(distributor_sH_ != 0);
-    assert(distributor_matS_ != 0);
-    assert(distributor_invS_ != 0);
+    assert(invS_ != nullptr);
+    assert(dm_ != nullptr);
+    assert(localX_ != nullptr);
+    assert(localT_ != nullptr);
+    assert(submatT_ != nullptr);
+    assert(sH_ != nullptr);
+    assert(matHB_ != nullptr);
+    assert(distributor_sH_ != nullptr);
+    assert(distributor_matS_ != nullptr);
+    assert(distributor_invS_ != nullptr);
 
     // if(onpe0)cout<<"delete invS"<<endl;
     delete invS_;
@@ -215,7 +215,7 @@ void ProjectedMatricesSparse::updateSubMatT()
 /* compute theta = invB * Hij */
 void ProjectedMatricesSparse::updateTheta()
 {
-    assert(invS_ != NULL);
+    assert(invS_ != nullptr);
 
     update_theta_tm_.start();
 
@@ -238,8 +238,8 @@ void ProjectedMatricesSparse::updateTheta()
 
 double ProjectedMatricesSparse::getExpectationH()
 {
-    assert(invS_ != NULL);
-    assert(matHB_ != 0);
+    assert(invS_ != nullptr);
+    assert(matHB_ != nullptr);
     //   assert(matHB_->n() != 0);
 
     return dm_->getTraceDotProductWithMat(matHB_);
@@ -248,8 +248,8 @@ double ProjectedMatricesSparse::getExpectationH()
 double ProjectedMatricesSparse::getExpectationMat(
     VariableSizeMatrix<sparserow>* mat)
 {
-    assert(invS_ != NULL);
-    assert(mat != 0);
+    assert(invS_ != nullptr);
+    assert(mat != nullptr);
     assert(mat->n() != 0);
 
     return dm_->getTraceDotProductWithMat(mat);
@@ -370,7 +370,7 @@ double ProjectedMatricesSparse::getNel() const { return 2. * dim_; }
 double ProjectedMatricesSparse::getEigSum()
 {
     if (dim_ == 0) return 0.;
-    assert(invS_ != NULL);
+    assert(invS_ != nullptr);
     eigsum_tm_.start();
     /* local functions for computing trace */
     std::vector<int> locfcns;
@@ -396,7 +396,7 @@ double ProjectedMatricesSparse::getEigSum()
 double ProjectedMatricesSparse::getLinDependent2states(
     int& st1, int& st2, const bool print_flag) const
 {
-    assert((*invS_).gramMat() != 0);
+    assert((*invS_).gramMat() != nullptr);
 
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     MPI_Comm comm   = mmpi.commSameSpin();
@@ -715,7 +715,7 @@ void ProjectedMatricesSparse::computeGenEigenInterval(
     std::vector<double>& interval, const int maxits, const double pad)
 {
     srand(13579);
-    assert(invS_ != 0);
+    assert(invS_ != nullptr);
     assert(sH_->n() == invS_->gramMat()->n());
 
     eig_interval_tm_.start();

--- a/src/SP2.cc
+++ b/src/SP2.cc
@@ -49,7 +49,7 @@ SP2::SP2(const double tol, const bool distributed)
 
 SP2::~SP2()
 {
-    assert(Xi_ != 0);
+    assert(Xi_ != nullptr);
 #ifdef HAVE_BML
     bml_deallocate(&Xi_);
     bml_deallocate(&Xi_sq_);

--- a/src/ShortSightedInverse.cc
+++ b/src/ShortSightedInverse.cc
@@ -188,8 +188,7 @@ int ShortSightedInverse::solve()
 
             /* Update invS */
             const int* row = (int*)(*invS_).getTableValue(locfcns_[i]);
-            if (row == nullptr)
-                std::cout << "Row index is NULL !!!" << std::endl;
+            assert(row != nullptr);
             const int* cols = (*gramMat_).rowIndexes();
             (*invS_).initializeLocalRow(m, *row, cols, solptr);
         }
@@ -322,7 +321,7 @@ void ShortSightedInverse::computeInvS(
         if (recompute_pc_ == true)
         {
             pc_setup_tm_.start();
-            assert(precon_ == 0);
+            assert(precon_ == nullptr);
             //          precon_ = new
             //          PreconILU<pcdatatype>(LSMat,droptol_,MaxFil_,lof_);
             precon_
@@ -543,7 +542,7 @@ void ShortSightedInverse::printTimers(std::ostream& os)
 
 void ShortSightedInverse::printGramMM(std::ofstream& tfile)
 {
-    assert(gramMat_ != 0);
+    assert(gramMat_ != nullptr);
 
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     int n           = locfcns_.size();

--- a/src/SinCosOps.cc
+++ b/src/SinCosOps.cc
@@ -477,7 +477,7 @@ void SinCosOps<T>::computeDiag2states(
                 if (orbitals.overlapping_gids_[iloc][mycolor] == st[ic])
                 {
                     const ORBDTYPE* const ppsii = orbitals.psi(mycolor);
-                    assert(ppsii != 0);
+                    assert(ppsii != nullptr);
                     double atmp[6]  = { 0., 0., 0., 0., 0., 0. };
                     const int ixend = loc_length * (iloc + 1);
 
@@ -568,7 +568,7 @@ void SinCosOps<T>::compute2states(
                 if (orbitals.overlapping_gids_[iloc][mycolor] == st[ic])
                 {
                     const ORBDTYPE* const ppsii = orbitals.psi(mycolor);
-                    assert(ppsii != 0);
+                    assert(ppsii != nullptr);
                     for (int jc = 0; jc <= ic; jc++)
                         if (color_st[jc] >= 0)
                         {
@@ -577,7 +577,7 @@ void SinCosOps<T>::compute2states(
                             {
                                 const ORBDTYPE* const ppsij
                                     = orbitals.psi(color_st[jc]);
-                                assert(ppsij != 0);
+                                assert(ppsij != nullptr);
 
                                 double atmp[6]  = { 0., 0., 0., 0., 0., 0. };
                                 const int ixend = loc_length * (iloc + 1);

--- a/src/Species.cc
+++ b/src/Species.cc
@@ -263,8 +263,11 @@ void Species::read_1species(const string& filename)
 
     if (mmpi.instancePE0())
     {
-        tfile->close();
-        delete tfile;
+        if (tfile != nullptr)
+        {
+            tfile->close();
+            delete tfile;
+        }
     }
 #ifdef DEBUG
     (*MPIdata::sout) << "Potential read" << endl;
@@ -542,7 +545,7 @@ void Species::initPotentials(
 
     if (printFlag && !ct.restart_run)
     {
-        assert(tfile != 0);
+        assert(tfile != nullptr);
         tfile->close();
         delete tfile;
     }

--- a/src/SpreadPenalty.cc
+++ b/src/SpreadPenalty.cc
@@ -26,7 +26,7 @@ void SpreadPenalty<T>::addResidual(T& phi, T& res, bool xlbomd)
 {
     Control& ct = *(Control::instance());
 
-    assert(spreadf_ != 0);
+    assert(spreadf_ != nullptr);
     assert(spread2_target_ >= 0.);
 
     // compute data to be used to evaluate spreads and centers
@@ -263,7 +263,7 @@ void SpreadPenalty<T>::computeAndAddResidualSpreadPenalty(
 template <class T>
 double SpreadPenalty<T>::evaluateEnergy(const T& phi)
 {
-    assert(spreadf_ != 0);
+    assert(spreadf_ != nullptr);
     assert(spread2_target_ >= 0.);
     assert(dampingFactor_ > 0.);
 

--- a/src/SpreadPenaltyVolume.cc
+++ b/src/SpreadPenaltyVolume.cc
@@ -21,7 +21,7 @@ void SpreadPenaltyVolume<T>::addResidual(T& phi, T& res)
     Control& ct     = *(Control::instance());
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
 
-    assert(spreadf_ != 0);
+    assert(spreadf_ != nullptr);
     assert(spread_target_ >= 0.);
     assert(dampingFactor_ > 0.);
 
@@ -276,7 +276,7 @@ void SpreadPenaltyVolume<T>::computeAndAddResidualSpreadPenalty(
 template <class T>
 double SpreadPenaltyVolume<T>::evaluateEnergy(const T& phi)
 {
-    assert(spreadf_ != 0);
+    assert(spreadf_ != nullptr);
     assert(spread_target_ >= 0.);
     assert(dampingFactor_ > 0.);
 

--- a/src/hdf_tools.cc
+++ b/src/hdf_tools.cc
@@ -264,12 +264,21 @@ void write2d(hid_t file_id, const string& datasetname, vector<string>& data,
     H5Tclose(strtype);
 
     status = H5Sclose(dataspaceA_id);
+    if (status < 0)
+    {
+        cerr << "write2d(), H5Sclose failed!!!" << endl;
+    }
+
     status = H5Aclose(attribute_id);
+    if (status < 0)
+    {
+        cerr << "write2d(), H5Aclose failed!!!" << endl;
+    }
+
     status = H5Dclose(dataset_id);
     if (status < 0)
     {
         cerr << "write2d(), H5Dclose failed!!!" << endl;
-        return;
     }
 }
 

--- a/src/linear_algebra/mputils.cc
+++ b/src/linear_algebra/mputils.cc
@@ -19,6 +19,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <vector>
 
 Timer dgemm_tm("dgemm");
 Timer sgemm_tm("sgemm");
@@ -209,13 +210,13 @@ void MPsyrk(const char uplo, const char trans, const int n, const int k,
     if (trans == 'N' || trans == 'n')
     {
         /* buffer to hold accumulation in double */
-        double* buff = new double[n];
+        std::vector<double> buff(n);
         if (uplo == 'U' || uplo == 'u')
         {
             for (int j = 0; j < n; j++)
             {
                 const int len = j + 1;
-                memset(buff, 0, len * sizeof(double));
+                std::fill(buff.begin(), buff.begin() + len, 0.);
                 for (int l = 0; l < k; l++)
                 {
                     /* pointer to beginning of column l in matrix a */
@@ -224,7 +225,7 @@ void MPsyrk(const char uplo, const char trans, const int n, const int k,
                     double mult
                         = (double)(alpha
                                    * colL[j]); // same as alpha * a[lda*l + j];
-                    MPaxpy(len, mult, colL, buff);
+                    MPaxpy(len, mult, colL, buff.data());
                 }
                 /* Update col j of upper part of matrix C. */
                 /* Get pointer to beginning of column j in C. */
@@ -239,7 +240,7 @@ void MPsyrk(const char uplo, const char trans, const int n, const int k,
             for (int j = 0; j < n; j++)
             {
                 const int len = n - (j + 1);
-                memset(buff, 0, len * sizeof(double));
+                std::fill(buff.begin(), buff.begin() + len, 0.);
                 for (int l = 0; l < k; l++)
                 {
                     /* pointer to beginning of column l in matrix a */
@@ -248,7 +249,7 @@ void MPsyrk(const char uplo, const char trans, const int n, const int k,
                     double mult
                         = (double)(alpha
                                    * colL[0]); // same as alpha * a[lda*l + j];
-                    MPaxpy(len, mult, colL, buff);
+                    MPaxpy(len, mult, colL, buff.data());
                 }
                 /* Update col j of upper part of matrix C. */
                 /* Get pointer to beginning of column j in C. */
@@ -340,17 +341,17 @@ void LinearAlgebraUtils<MemorySpace::Host>::MPgemm(const char transa,
         if (transa == 'N' || transa == 'n')
         {
             /* buffer to hold accumulation in double */
-            double* buff = new double[m];
+            std::vector<double> buff(m);
             for (int j = 0; j < n; j++)
             {
-                memset(buff, 0, m * sizeof(double));
+                std::fill(buff.begin(), buff.end(), 0.);
                 for (int l = 0; l < k; l++)
                 {
                     /* pointer to beginning of column l in matrix a */
                     const T1* colL = a + lda * l;
                     /* get multiplier */
                     double mult = (double)(alpha * b[ldb * j + l]);
-                    MPaxpy(m, mult, colL, buff);
+                    MPaxpy(m, mult, colL, buff.data());
                 }
                 /* Update col j of of result matrix C. */
                 /* Get pointer to beginning of column j in C. */
@@ -382,17 +383,17 @@ void LinearAlgebraUtils<MemorySpace::Host>::MPgemm(const char transa,
         if (transa == 'N' || transa == 'n')
         {
             /* buffer to hold accumulation in double */
-            double* buff = new double[m];
+            std::vector<double> buff(m);
             for (int j = 0; j < n; j++)
             {
-                memset(buff, 0, m * sizeof(double));
+                std::fill(buff.begin(), buff.end(), 0.);
                 for (int l = 0; l < k; l++)
                 {
                     /* pointer to beginning of column l in matrix a */
                     const T1* colL = a + lda * l;
                     /* get multiplier */
                     double mult = (double)(alpha * b[ldb * l + j]);
-                    MPaxpy(m, mult, colL, buff);
+                    MPaxpy(m, mult, colL, buff.data());
                 }
                 /* Update col j of of result matrix C. */
                 /* Get pointer to beginning of column j in C. */
@@ -461,17 +462,17 @@ void LinearAlgebraUtils<MemorySpace::Host>::MPgemm<float, float, float>(
         if (transa == 'N' || transa == 'n')
         {
             /* buffer to hold accumulation in double */
-            double* buff = new double[m];
+            std::vector<double> buff(m);
             for (int j = 0; j < n; j++)
             {
-                memset(buff, 0, m * sizeof(double));
+                std::fill(buff.begin(), buff.end(), 0);
                 for (int l = 0; l < k; l++)
                 {
                     /* pointer to beginning of column l in matrix a */
                     const float* colL = a + lda * l;
                     /* get multiplier */
                     double mult = (double)(alpha * b[ldb * j + l]);
-                    MPaxpy(m, mult, colL, buff);
+                    MPaxpy(m, mult, colL, buff.data());
                 }
                 /* Update col j of of result matrix C. */
                 /* Get pointer to beginning of column j in C. */
@@ -501,17 +502,17 @@ void LinearAlgebraUtils<MemorySpace::Host>::MPgemm<float, float, float>(
         if (transa == 'N' || transa == 'n')
         {
             /* buffer to hold accumulation in double */
-            double* buff = new double[m];
+            std::vector<double> buff(m);
             for (int j = 0; j < n; j++)
             {
-                memset(buff, 0, m * sizeof(double));
+                std::fill(buff.begin(), buff.end(), 0);
                 for (int l = 0; l < k; l++)
                 {
                     /* pointer to beginning of column l in matrix a */
                     const float* colL = a + lda * l;
                     /* get multiplier */
                     double mult = (double)(alpha * b[ldb * l + j]);
-                    MPaxpy(m, mult, colL, buff);
+                    MPaxpy(m, mult, colL, buff.data());
                 }
                 /* Update col j of of result matrix C. */
                 /* Get pointer to beginning of column j in C. */
@@ -700,13 +701,13 @@ void MPsyrk(const char uplo, const char trans, const int n, const int k,
     if (trans == 'N' || trans == 'n')
     {
         /* buffer to hold accumulation in double */
-        double* buff = new double[n];
+        std::vector<double> buff(n);
         if (uplo == 'U' || uplo == 'u')
         {
             for (int j = 0; j < n; j++)
             {
                 const int len = j + 1;
-                memset(buff, 0, len * sizeof(double));
+                std::fill(buff.begin(), buff.begin() + len, 0.);
                 for (int l = 0; l < k; l++)
                 {
                     /* pointer to beginning of column l in matrix a */
@@ -715,7 +716,7 @@ void MPsyrk(const char uplo, const char trans, const int n, const int k,
                     double mult
                         = (double)(alpha
                                    * colL[j]); // same as alpha * a[lda*l + j];
-                    MPaxpy(len, mult, colL, buff);
+                    MPaxpy(len, mult, colL, buff.data());
                 }
                 /* Update col j of upper part of matrix C. */
                 /* Get pointer to beginning of column j in C. */
@@ -730,7 +731,7 @@ void MPsyrk(const char uplo, const char trans, const int n, const int k,
             for (int j = 0; j < n; j++)
             {
                 const int len = n - (j + 1);
-                memset(buff, 0, len * sizeof(double));
+                std::fill(buff.begin(), buff.begin() + len, 0.);
                 for (int l = 0; l < k; l++)
                 {
                     /* pointer to beginning of column l in matrix a */
@@ -739,7 +740,7 @@ void MPsyrk(const char uplo, const char trans, const int n, const int k,
                     double mult
                         = (double)(alpha
                                    * colL[0]); // same as alpha * a[lda*l + j];
-                    MPaxpy(len, mult, colL, buff);
+                    MPaxpy(len, mult, colL, buff.data());
                 }
                 /* Update col j of upper part of matrix C. */
                 /* Get pointer to beginning of column j in C. */

--- a/src/local_matrices/LocalMatrices.cc
+++ b/src/local_matrices/LocalMatrices.cc
@@ -114,12 +114,12 @@ void LocalMatrices<T>::syrk(
     assert(iloc < subdiv_);
     assert(iloc < (int)ptr_matrices_.size());
     assert(k <= lda);
-    assert(ptr_matrices_[iloc] != 0);
+    assert(ptr_matrices_[iloc] != nullptr);
     assert(m_ > 0);
     assert(m_ == n_);
 
     T* const ssiloc = ptr_matrices_[iloc];
-    assert(ssiloc != 0);
+    assert(ssiloc != nullptr);
 
     const double zero = 0.;
     const double one  = 1.;
@@ -139,12 +139,12 @@ void LocalMatrices<T>::syrk(
     assert(iloc < subdiv_);
     assert(iloc < (int)ptr_matrices_.size());
     assert(k <= lda);
-    assert(ptr_matrices_[iloc] != 0);
+    assert(ptr_matrices_[iloc] != nullptr);
     assert(m_ > 0);
     assert(m_ == n_);
 
     T* const ssiloc = ptr_matrices_[iloc];
-    assert(ssiloc != 0);
+    assert(ssiloc != nullptr);
 
     const double zero = 0.;
     const double one  = 1.;
@@ -163,10 +163,10 @@ void LocalMatrices<T>::gemm(const int iloc, const int ma, const double* const a,
     assert(iloc < subdiv_);
     assert(iloc < (int)ptr_matrices_.size());
     assert(ma <= lda);
-    assert(ptr_matrices_[iloc] != 0);
+    assert(ptr_matrices_[iloc] != nullptr);
 
     T* const c = ptr_matrices_[iloc];
-    assert(c != 0);
+    assert(c != nullptr);
 
     LinearAlgebraUtils<MemorySpace::Host>::MPgemm(
         't', 'n', m_, n_, ma, 1., a, lda, b, ldb, 0., c, m_);
@@ -179,10 +179,10 @@ void LocalMatrices<T>::gemm(const int iloc, const int ma, const float* const a,
     assert(iloc < subdiv_);
     assert(iloc < (int)ptr_matrices_.size());
     assert(ma <= lda);
-    assert(ptr_matrices_[iloc] != 0);
+    assert(ptr_matrices_[iloc] != nullptr);
 
     T* const c = ptr_matrices_[iloc];
-    assert(c != 0);
+    assert(c != nullptr);
 
     LinearAlgebraUtils<MemorySpace::Host>::MPgemm(
         't', 'n', m_, n_, ma, 1., a, lda, b, ldb, 0., c, m_);
@@ -209,7 +209,7 @@ void LocalMatrices<T>::gemm(const char transa, const char transb,
         const T* const bmat = matB.getSubMatrix(iloc);
         // get pointer to local storage
         T* const c = ptr_matrices_[iloc];
-        assert(c != 0);
+        assert(c != nullptr);
 
         // do matrix multiplication
         LinearAlgebraUtils<MemorySpace::Host>::MPgemm(transa, transb, m_, n_,

--- a/src/main.cc
+++ b/src/main.cc
@@ -700,6 +700,10 @@ int main(int argc, char** argv)
 #endif
 
     mpirc = MPI_Finalize();
+    if (mpirc != MPI_SUCCESS)
+    {
+        cerr << "MPI Finalize failed!!!" << endl;
+    }
 
     time_t tt;
     time(&tt);

--- a/src/mlwf.cc
+++ b/src/mlwf.cc
@@ -214,17 +214,18 @@ void MGmol<T>::wftransform(T* orbitals, T* work_orbitals, Ions& ions)
     // print transformation matrix
     if (ct.getOrbitalsType() == OrbitalsType::Eigenfunctions && !ct.AtomsMove())
     {
+        assert(mlwt != nullptr);
         mlwt->printTransform();
     }
 
     if (createMLWF)
     {
-        assert(mlwt != NULL);
+        assert(mlwt != nullptr);
         delete mlwt;
     }
     if (createNOOT)
     {
-        assert(noot != NULL);
+        assert(noot != nullptr);
         delete noot;
     }
 }

--- a/src/pb/GridFunc.cc
+++ b/src/pb/GridFunc.cc
@@ -420,7 +420,7 @@ GridFunc<T>::GridFunc(const T* const src, const Grid& new_grid, const short px,
     assert(grid_.sizeg() > 0);
     assert(grid_.inc(2) == 1);
     assert(dis == 'd' || dis == 'g' || dis == 's');
-    assert(src != 0);
+    assert(src != nullptr);
 
     if (!grid_.active()) return;
 
@@ -669,6 +669,7 @@ GridFunc<T> GridFunc<T>::operator*(const double val)
 
     T* __restrict__ tu       = &tmp.uu_[0];
     const T* __restrict__ pu = &uu_[0];
+    assert(tu != nullptr);
     for (int i = 0; i < n; i++)
         tu[i] = val * pu[i];
 
@@ -1765,7 +1766,7 @@ void GridFunc<T>::init_vect(T* vv, const char dis) const
     if (!grid_.active()) return;
 
     assert(grid_.inc(2) == 1);
-    assert(vv != 0);
+    assert(vv != nullptr);
 
     if (dis == 'g')
     {
@@ -1786,7 +1787,7 @@ void GridFunc<T>::getValues(T2* vv) const
     if (!grid_.active()) return;
 
     assert(grid_.inc(2) == 1);
-    assert(vv != 0);
+    assert(vv != nullptr);
 
     const short nghosts = ghost_pt();
 
@@ -2480,7 +2481,7 @@ void GridFunc<T>::setBoundaryValuesBeforeTrade()
     if (directionMultipole_[0] || directionMultipole_[1]
         || directionMultipole_[2])
     {
-        assert(bc_func_ != NULL);
+        assert(bc_func_ != nullptr);
         setBoundaryValues(*bc_func_, directionMultipole_);
     }
 }
@@ -3883,6 +3884,7 @@ void GridFunc<T>::test_trade_boundaries()
     MPI_Comm_size(mype_env().comm(), &ntasks);
     assert(ntasks == mype_env().n_mpi_tasks());
 
+    assert(uu_ != nullptr);
     memset(uu_, 0, grid_.sizeg() * sizeof(T));
 
     for (ix = ghost_pt(); ix < ghost_pt() + dim(0); ix++)

--- a/src/pb/PEenv.cc
+++ b/src/pb/PEenv.cc
@@ -297,7 +297,7 @@ void PEenv::task2xyz()
 
 void PEenv::setup_my_neighbors()
 {
-    assert(cart_comm_ != 0);
+    assert(cart_comm_ != nullptr);
 
     if (color_ == 0)
     {
@@ -400,7 +400,7 @@ int PEenv::geom(const int nx, const int ny, const int nz, const int bias)
     n[1] = ny;
     n[2] = nz, n[3] = n_mpi_tasks_;
 #ifndef NDEBUG
-    if (onpe0_ && os_ != 0)
+    if (onpe0_ && os_ != nullptr)
         (*os_) << "n=" << n[0] << ", " << n[1] << ", " << n[2] << ", " << n[3]
                << std::endl;
 #endif
@@ -541,7 +541,7 @@ int PEenv::geom(const int nx, const int ny, const int nz, const int bias)
                 if (fac[imax0][k] > 0 && fac[3][k] > 0)
                 {
 #ifndef NDEBUG
-                    if (onpe0_ && os_ != 0)
+                    if (onpe0_ && os_ != nullptr)
                         (*os_) << "Divide domain along direction " << imax0
                                << std::endl;
 #endif
@@ -560,7 +560,7 @@ int PEenv::geom(const int nx, const int ny, const int nz, const int bias)
                 if (fac[imax1][k] > 0 && fac[3][k] > 0)
                 {
 #ifndef NDEBUG
-                    if (onpe0_ && os_ != 0)
+                    if (onpe0_ && os_ != nullptr)
                         (*os_) << "Divide domain along direction " << imax1
                                << std::endl;
 #endif
@@ -579,7 +579,7 @@ int PEenv::geom(const int nx, const int ny, const int nz, const int bias)
                 if (fac[imax2][k] > 0 && fac[3][k] > 0)
                 {
 #ifndef NDEBUG
-                    if (onpe0_ && os_ != 0)
+                    if (onpe0_ && os_ != nullptr)
                         (*os_) << "Divide domain along direction " << imax2
                                << std::endl;
 #endif
@@ -595,7 +595,7 @@ int PEenv::geom(const int nx, const int ny, const int nz, const int bias)
     }
 
 #ifndef NDEBUG
-    if (onpe0_ && os_ != 0)
+    if (onpe0_ && os_ != nullptr)
     {
         (*os_) << " Subdomain: " << n[0] << " * " << n[1] << " * " << n[2]
                << std::endl;
@@ -622,7 +622,7 @@ void PEenv::split_comm(const int nx, const int ny, const int nz, const int bias)
     {
         if (comm_active_ != comm_)
         {
-            assert(comm_active_ != NULL);
+            assert(comm_active_ != nullptr);
             MPI_Comm_free(&comm_active_);
         }
         for (int i = 0; i < 3; i++)
@@ -652,7 +652,7 @@ void PEenv::split_comm(const int nx, const int ny, const int nz, const int bias)
         }
         MPI_Comm_size(comm_active_, &n_mpi_tasks_);
 #ifndef NDEBUG
-        if (color_ == 0 && onpe0_ && os_ != 0)
+        if (color_ == 0 && onpe0_ && os_ != nullptr)
         {
             (*os_) << n_mpi_tasks_ << " MPI tasks" << std::endl;
         }

--- a/src/quench.cc
+++ b/src/quench.cc
@@ -106,7 +106,7 @@ void MGmol<T>::adaptLR(
         // if ct.lr_volume_calc true, calculate volume base on spreads
         if (ct.lr_volume_calc == 1)
         {
-            assert(ot != NULL);
+            assert(ot != nullptr);
             const double vol_rotated = ot->volume();
             const double vol_spreads = spreadf->volume();
             if (onpe0 && ct.verbose > 1)
@@ -122,7 +122,7 @@ void MGmol<T>::adaptLR(
         }
         else if (ct.lr_volume_calc == 2)
         {
-            assert(ot != NULL);
+            assert(ot != nullptr);
             if (onpe0) os_ << " Adapt LR using NOLMO spreads" << std::endl;
             const double ratio = ct.cut_radius;
             avg                = lrs_->updateRadii(ot, ratio);

--- a/src/radial/RadialMeshFunction.cc
+++ b/src/radial/RadialMeshFunction.cc
@@ -539,7 +539,7 @@ void RadialMeshFunction::rft(RadialMeshFunction& filt_func, const int lval,
 void RadialMeshFunction::printLocalPot(
     const std::string& name, const short ll, std::ofstream* tfile)
 {
-    assert(tfile != 0);
+    assert(tfile != nullptr);
 
     const std::vector<double>& potloc = y_[0];
 

--- a/src/readInput.cc
+++ b/src/readInput.cc
@@ -32,7 +32,7 @@ int MGmol<T>::readLRsFromInput(std::ifstream* tfile)
 {
     Control& ct(*(Control::instance()));
 
-    assert(lrs_ != 0);
+    assert(lrs_ != nullptr);
     assert(ct.restart_info < 3 || !ct.isLocMode());
 
     if (ct.verbose > 0) printWithTimeStamp("readLRsFromInput", os_);

--- a/src/sparse_linear_algebra/DataDistribution.cc
+++ b/src/sparse_linear_algebra/DataDistribution.cc
@@ -747,7 +747,7 @@ void DataDistribution::reduceDataSizes(const short dir,
 }
 void DataDistribution::setPointersToRecvData(const char* rbuf)
 {
-    assert(rbuf != NULL);
+    assert(rbuf != nullptr);
 
     rbuf_nrows_ptr_ = (int*)rbuf;
     /* check if matrix is nonzero */

--- a/src/sparse_linear_algebra/LinearSolver.cc
+++ b/src/sparse_linear_algebra/LinearSolver.cc
@@ -36,7 +36,7 @@ int LinearSolver::fgmres(const LinearSolverMatrix<lsdatatype>& LSMat,
     const double tol, const int im, const int maxits)
 {
     int i, i1, ii, j, k, k1, its, im1, pti, pti1, ptih, one = 1;
-    double *hh, *c, *s, *rs, t;
+    double *c, *s, *rs, t;
     double negt, beta, eps1, gam, *vv, *z;
 
     const int n        = LSMat.n();
@@ -51,9 +51,8 @@ int LinearSolver::fgmres(const LinearSolverMatrix<lsdatatype>& LSMat,
     z    = new double[(imsz)];
     memset(z, 0, imsz * sizeof(double));
     imsz = im1 * (im + 3);
-    hh   = new double[(imsz)];
-    memset(hh, 0, imsz * sizeof(double));
-    c  = hh + im1 * im;
+    std::vector<double> hh(imsz, 0.);
+    c  = hh.data() + im1 * im;
     s  = c + im1;
     rs = s + im1;
     /*-------------------- outer loop starts here */
@@ -81,10 +80,8 @@ int LinearSolver::fgmres(const LinearSolverMatrix<lsdatatype>& LSMat,
         if (its == 0) eps1 = tol * beta;
         /*--------------------initialize 1-st term  of rhs of hessenberg mtx */
         rs[0] = beta;
-        i     = 0;
         /*-------------------- Krylov loop*/
-        i   = -1;
-        pti = pti1 = 0;
+        i = -1;
         while ((i < im - 1) && (beta > eps1) && (its++ < maxits))
         {
             i++;
@@ -177,7 +174,6 @@ int LinearSolver::fgmres(const LinearSolverMatrix<lsdatatype>& LSMat,
     resnorm_ = beta;
     delete[] vv;
     delete[] z;
-    delete[] hh;
     return (retval);
 }
 /*-----------------end of fgmres --------------------------------------- */
@@ -228,10 +224,9 @@ int LinearSolver::fgmres(const LinearSolverMatrix<lsdatatype>& LSMat,
         if (its == 0) eps1 = tol * beta;
         /*--------------------initialize 1-st term  of rhs of hessenberg mtx */
         rs[0] = beta;
-        i     = 0;
         /*-------------------- Krylov loop*/
-        i   = -1;
-        pti = pti1 = 0;
+        i    = -1;
+        pti1 = 0;
 
         while ((i < im - 1) && (beta > eps1) && (its++ < maxits))
         {

--- a/src/sparse_linear_algebra/PackedCommunicationBuffer.cc
+++ b/src/sparse_linear_algebra/PackedCommunicationBuffer.cc
@@ -64,7 +64,7 @@ PackedCommunicationBuffer::PackedCommunicationBuffer(const int bsize)
 /* Set data pointer positions on recv buffer */
 void PackedCommunicationBuffer::setupPackedDataPointers(const char* data)
 {
-    assert(data != 0);
+    assert(data != nullptr);
 
     // setup_data_ptr_tm_.start();
     int* iptr        = (int*)data;

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -52,7 +52,7 @@ void stripLeadingAndTrailingBlanks(std::string& stringToModify)
 {
     if (stringToModify.empty()) return;
 
-    int startIndex = stringToModify.find_first_not_of(" ");
+    int startIndex = stringToModify.find_first_not_of(' ');
     // int endIndex   = stringToModify.find_last_not_of(" ");
     int endIndex = stringToModify.find_last_of("0123456789");
     // cerr<<"startIndex="<<startIndex<<endl;

--- a/src/tools/MGmol_MPI.cc
+++ b/src/tools/MGmol_MPI.cc
@@ -61,7 +61,7 @@ void MGmol_MPI::printTimers(std::ostream& os)
 void MGmol_MPI::setupComm(
     const MPI_Comm comm, const bool with_spin, const int nimages)
 {
-    assert(pinstance_ == 0);
+    assert(pinstance_ == nullptr);
 
     comm_global_ = comm;
 
@@ -552,8 +552,8 @@ int MGmol_MPI::exchangeDataSpin(
 {
     if (nspin_ == 1) return 0;
 
-    assert(localdata != 0);
-    assert(remotedata != 0);
+    assert(localdata != nullptr);
+    assert(remotedata != nullptr);
     assert(myspin_ == 0 || myspin_ == 1);
 
     assert(comm_different_spin_ != MPI_COMM_NULL);
@@ -590,8 +590,8 @@ int MGmol_MPI::exchangeDataSpin(
 {
     if (nspin_ == 1) return 0;
 
-    assert(localdata != 0);
-    assert(remotedata != 0);
+    assert(localdata != nullptr);
+    assert(remotedata != nullptr);
     assert(myspin_ == 0 || myspin_ == 1);
 
     assert(comm_different_spin_ != MPI_COMM_NULL);
@@ -1134,6 +1134,10 @@ int MGmol_MPI::allGatherV(
     int* recvcounts = new int[size_];
     int mpi_err     = MPI_Allgather(
         &sendcount, 1, MPI_INT, recvcounts, 1, MPI_INT, comm_spin_);
+    if (mpi_err != MPI_SUCCESS)
+    {
+        MGMOL_MPI_ERROR("MPI_Allgather in MGmol_MPI::allGatherV() !!!");
+    }
 
     int* displs = new int[size_];
     displs[0]   = 0;

--- a/src/tools/mgmol_mpi_tools.cc
+++ b/src/tools/mgmol_mpi_tools.cc
@@ -20,7 +20,7 @@ namespace mgmol_tools
 int reduce(int* sendbuf, int* recvbuf, int count, MPI_Op op, const int root,
     const MPI_Comm comm)
 {
-    assert(comm != 0);
+    assert(comm != MPI_COMM_NULL);
     int mpi_err = MPI_Reduce(sendbuf, recvbuf, count, MPI_INT, op, root, comm);
     if (mpi_err != MPI_SUCCESS)
     {
@@ -33,7 +33,7 @@ int reduce(int* sendbuf, int* recvbuf, int count, MPI_Op op, const int root,
 int reduce(int* buf, int count, MPI_Op op, const int root, const MPI_Comm comm)
 {
     int mype = 0;
-    assert(comm != 0);
+    assert(comm != MPI_COMM_NULL);
     MPI_Comm_rank(comm, &mype);
 
     int* recvbuf = new int[count];
@@ -48,7 +48,7 @@ int reduce(int* buf, int count, MPI_Op op, const int root, const MPI_Comm comm)
 int reduce(double* sendbuf, double* recvbuf, int count, MPI_Op op,
     const int root, const MPI_Comm comm)
 {
-    assert(comm != 0);
+    assert(comm != MPI_COMM_NULL);
     int mpi_err
         = MPI_Reduce(sendbuf, recvbuf, count, MPI_DOUBLE, op, root, comm);
     if (mpi_err != MPI_SUCCESS)
@@ -62,7 +62,7 @@ int reduce(double* sendbuf, double* recvbuf, int count, MPI_Op op,
 int reduce(float* sendbuf, float* recvbuf, int count, MPI_Op op, const int root,
     const MPI_Comm comm)
 {
-    assert(comm != 0);
+    assert(comm != MPI_COMM_NULL);
     int mpi_err
         = MPI_Reduce(sendbuf, recvbuf, count, MPI_FLOAT, op, root, comm);
     if (mpi_err != MPI_SUCCESS)
@@ -76,7 +76,7 @@ int reduce(float* sendbuf, float* recvbuf, int count, MPI_Op op, const int root,
 int reduce(short* sendbuf, short* recvbuf, int count, MPI_Op op, const int root,
     const MPI_Comm comm)
 {
-    assert(comm != 0);
+    assert(comm != MPI_COMM_NULL);
     int mpi_err
         = MPI_Reduce(sendbuf, recvbuf, count, MPI_SHORT, op, root, comm);
     if (mpi_err != MPI_SUCCESS)
@@ -92,7 +92,7 @@ int gatherV(std::vector<std::string>& sendbuf,
 {
     int mype = 0;
     int size = 1;
-    assert(comm != 0);
+    assert(comm != MPI_COMM_NULL);
     MPI_Comm_rank(comm, &mype);
     MPI_Comm_size(comm, &size);
 
@@ -129,6 +129,11 @@ int gatherV(std::vector<std::string>& sendbuf,
     int* recvcounts = new int[size];
     int mpi_err     = MPI_Gather(
         &sendcount, 1, MPI_INT, recvcounts, 1, MPI_INT, root, comm);
+    if (mpi_err != MPI_SUCCESS)
+    {
+        std::cerr << "ERROR in MPI_Gather in MGmol_MPI::GatherV() !!!"
+                  << std::endl;
+    }
 
     int* displs = new int[size];
     if (mype == root)


### PR DESCRIPTION
Add a `.clang-tidy` file and fix some of the warnings from `clang-tidy`. Most fixes are just `NULL` to `nullptr` but `clang-tidy` also found a few memory leaks. There are still more warnings but it's a step in the right direction.