### PR TITLE
Hide use of SparseDistMatrix

### DIFF
--- a/src/DistMatrix/SparseDistMatrix.cc
+++ b/src/DistMatrix/SparseDistMatrix.cc
@@ -223,16 +223,22 @@ void SparseDistMatrix<T>::addData(const std::vector<T>& data, const int ld,
 }
 
 template <class T>
-void SparseDistMatrix<T>::addData(SquareSubMatrix<T>& mat)
+void SparseDistMatrix<T>::addData(
+    const SquareSubMatrix<T>& mat, const double tol)
 {
     const std::vector<int>& gid(mat.getGids());
     const int n = gid.size();
 
     for (int j = 0; j < n; j++)
+    {
+        assert(gid[j] >= 0);
+
         for (int i = 0; i < n; i++)
         {
-            push_back(gid[i], gid[j], mat.getLocalValue(i, j));
+            const double val = mat.getLocalValue(i, j);
+            if (fabs(val) > tol) push_back(gid[i], gid[j], val);
         }
+    }
 }
 
 template <class T>

--- a/src/DistMatrix/SparseDistMatrix.cc
+++ b/src/DistMatrix/SparseDistMatrix.cc
@@ -236,7 +236,7 @@ void SparseDistMatrix<T>::addData(
         for (int i = 0; i < n; i++)
         {
             const double val = mat.getLocalValue(i, j);
-            if (fabs(val) > tol) push_back(gid[i], gid[j], val);
+            if (std::abs(val) > tol) push_back(gid[i], gid[j], val);
         }
     }
 }

--- a/src/DistMatrix/SparseDistMatrix.h
+++ b/src/DistMatrix/SparseDistMatrix.h
@@ -120,7 +120,7 @@ public:
     void addData(const std::vector<T>& data, const int ld, const int ilow,
         const int ihi, const int jlow, const int jhi,
         const std::vector<int>& gids);
-    void addData(SquareSubMatrix<T>& mat);
+    void addData(const SquareSubMatrix<T>& mat, const double tol = 0.);
 
     void push_back(const int index1, const int index2, const T val);
 

--- a/src/GrassmanCG.h
+++ b/src/GrassmanCG.h
@@ -16,7 +16,6 @@
 #include "Hamiltonian.h"
 #include "Potentials.h"
 #include "ProjectedMatricesInterface.h"
-#include "SparseDistMatrix.h"
 
 #include <iostream>
 

--- a/src/Hamiltonian.cc
+++ b/src/Hamiltonian.cc
@@ -16,8 +16,6 @@
 #include "Potentials.h"
 #include "ProjectedMatrices.h"
 
-static int sparse_distmatrix_nb_partitions = 128;
-
 template <class T>
 Hamiltonian<T>::Hamiltonian()
 {

--- a/src/Hamiltonian.cc
+++ b/src/Hamiltonian.cc
@@ -162,7 +162,7 @@ void Hamiltonian<T>::applyLocal(
 // corresponding to the local part of the Hamiltonian
 template <>
 void Hamiltonian<LocGridOrbitals>::addHlocal2matrix(LocGridOrbitals& phi1,
-    LocGridOrbitals& phi2, dist_matrix::SparseDistMatrix<double>& hij,
+    LocGridOrbitals& phi2, dist_matrix::DistMatrix<double>& hij,
     const bool force)
 {
     applyLocal(phi2, force);
@@ -190,20 +190,6 @@ void Hamiltonian<ExtendedGridOrbitals>::addHlocal2matrix(
     phi1.addDotWithNcol2Matrix(*hlphi_, hij);
 
     // hij.print(std::cout, 0, 0, 5, 5);
-}
-
-template <>
-void Hamiltonian<LocGridOrbitals>::addHlocal2matrix(LocGridOrbitals& phi1,
-    LocGridOrbitals& phi2, dist_matrix::DistMatrix<DISTMATDTYPE>& hij,
-    const bool force)
-{
-    MGmol_MPI& mmpi = *(MGmol_MPI::instance());
-    dist_matrix::SparseDistMatrix<DISTMATDTYPE> sparse(
-        mmpi.commSameSpin(), hij, sparse_distmatrix_nb_partitions);
-
-    addHlocal2matrix(phi1, phi2, sparse, force);
-
-    sparse.parallelSumToDistMatrix();
 }
 
 template <class T>

--- a/src/Hamiltonian.h
+++ b/src/Hamiltonian.h
@@ -13,7 +13,6 @@
 
 #include "LapFactory.h"
 #include "ProjectedMatricesInterface.h"
-#include "SparseDistMatrix.h"
 #include "Timer.h"
 #include "VariableSizeMatrix.h"
 
@@ -45,9 +44,6 @@ public:
 
     const T& applyLocal(T& phi, const bool force = false);
 
-    void addHlocal2matrix(T& orbitals1, T& orbitals2,
-        dist_matrix::SparseDistMatrix<DISTMATDTYPE>& mat,
-        const bool force = false);
     void addHlocal2matrix(T& orbitals1, T& orbitals2,
         dist_matrix::DistMatrix<DISTMATDTYPE>& mat, const bool force = false);
     void addHlocal2matrix(T& orbitals1, T& orbitals2,

--- a/src/KBPsiMatrixSparse.cc
+++ b/src/KBPsiMatrixSparse.cc
@@ -23,8 +23,6 @@
 #include <limits.h>
 #define Ry2Ha 0.5;
 
-static int sparse_distmatrix_nb_partitions = 128;
-
 Timer KBPsiMatrixSparse::global_sum_tm_("KBPsiMatrixSparse::global_sum");
 Timer KBPsiMatrixSparse::compute_kbpsi_tm_("KBPsiMatrixSparse::compute_kbpsi");
 Timer KBPsiMatrixSparse::computeHvnlMatrix_tm_(

--- a/src/KBPsiMatrixSparse.h
+++ b/src/KBPsiMatrixSparse.h
@@ -71,9 +71,6 @@ class KBPsiMatrixSparse : public KBPsiMatrixInterface
         return (*kbBpsimat_).get_value(gid, st);
     }
 
-    //    void computeHvnlMatrix(const KBPsiMatrixSparse* const kbpsi, const
-    //    Ion&,
-    //        dist_matrix::SparseDistMatrix<DISTMATDTYPE>&) const;
     void computeHvnlMatrix(const KBPsiMatrixSparse* const kbpsi, const Ion&,
         SquareSubMatrix<double>& mat) const;
     void computeHvnlMatrix(const KBPsiMatrixSparse* const kbpsi2,

--- a/src/LocGridOrbitals.h
+++ b/src/LocGridOrbitals.h
@@ -23,7 +23,6 @@
 #include "Orbitals.h"
 #include "SaveData.h"
 #include "SinCosOps.h"
-#include "SparseDistMatrix.h"
 #include "global.h"
 
 #include "hdf5.h"
@@ -365,7 +364,7 @@ public:
         const LocGridOrbitals& orbitals, SquareLocalMatrices<MATDTYPE>&);
 
     void addDotWithNcol2Matrix(
-        LocGridOrbitals&, dist_matrix::SparseDistMatrix<DISTMATDTYPE>&) const;
+        LocGridOrbitals&, dist_matrix::DistMatrix<DISTMATDTYPE>&) const;
 
     void scal(const double alpha)
     {

--- a/src/MGmol.h
+++ b/src/MGmol.h
@@ -51,7 +51,6 @@ class IonicAlgorithm;
 #include "OrbitalsExtrapolation.h"
 #include "OrbitalsPreconditioning.h"
 #include "Rho.h"
-#include "SparseDistMatrix.h"
 #include "SpreadPenaltyInterface.h"
 #include "SpreadsAndCenters.h"
 
@@ -117,12 +116,6 @@ private:
     int read_restart_lrs(HDFrestart& h5f_file, const std::string& dset_name);
     int read_restart_data(HDFrestart& h5f_file, Rho<T>& rho, T& orbitals);
     void write_header();
-    void getKBPsiAndHij(T& orbitals_i, T& orbitals_j, Ions& ions,
-        KBPsiMatrixSparse* kbpsi, ProjectedMatricesInterface* projmatrices,
-        dist_matrix::SparseDistMatrix<DISTMATDTYPE>& sh);
-    void computeHij(T& orbitals_i, T& orbitals_j, const Ions& ions,
-        const KBPsiMatrixSparse* const kbpsi,
-        dist_matrix::SparseDistMatrix<DISTMATDTYPE>& sparseH);
     void getKBPsiAndHij(T& orbitals_i, T& orbitals_j, Ions& ions,
         KBPsiMatrixSparse* kbpsi, ProjectedMatricesInterface* projmatrices);
     void getKBPsiAndHij(T& orbitals_i, T& orbitals_j, Ions& ions,
@@ -222,8 +215,6 @@ public:
         T& orbitalsi, T& orbitalsj, dist_matrix::DistMatrix<double>& mat);
     void addHlocal2matrix(
         T& orbitalsi, T& orbitalsj, VariableSizeMatrix<SparseRow>& mat);
-    void addHlocal2matrix(T& orbitalsi, T& orbitalsj,
-        dist_matrix::SparseDistMatrix<double>& sparseH);
 
     void update_pot(const pb::GridFunc<POTDTYPE>& vh_init, const Ions& ions);
     void update_pot(const Ions& ions);

--- a/src/ProjectedMatrices.cc
+++ b/src/ProjectedMatrices.cc
@@ -21,6 +21,7 @@
 #include "ReplicatedWorkSpace.h"
 #include "SP2.h"
 #include "SparseDistMatrix.h"
+#include "SquareSubMatrix2DistMatrix.h"
 #include "fermi.h"
 #include "tools.h"
 

--- a/src/ProjectedMatrices.h
+++ b/src/ProjectedMatrices.h
@@ -19,7 +19,7 @@
 #include "MPIdata.h"
 #include "ProjectedMatricesInterface.h"
 #include "SquareLocalMatrices.h"
-#include "SquareSubMatrix2DistMatrix.h"
+#include "SquareSubMatrix.h"
 #include "Timer.h"
 #include "tools.h"
 

--- a/src/SquareSubMatrix2DistMatrix.cc
+++ b/src/SquareSubMatrix2DistMatrix.cc
@@ -24,27 +24,7 @@ void SquareSubMatrix2DistMatrix::convert(const SquareSubMatrix<T>& src,
 
     const short chromatic_number = (short)gids.size();
 
-    // double loop over colors
-    for (short icolor = 0; icolor < chromatic_number; icolor++)
-    {
-        const int st1 = gids[icolor];
-        if (st1 != -1)
-        {
-            for (short jcolor = 0; jcolor < chromatic_number; jcolor++)
-            {
-                const int st2 = gids[jcolor];
-                if (st2 != -1)
-                {
-                    const T value = src.getLocalValue(icolor, jcolor);
-                    if (fabs(value) > tol)
-                    {
-                        dst.push_back(st1, st2, value);
-                    }
-                }
-            }
-
-        } // jcolor
-    } // icolor
+    dst.addData(src, tol);
 }
 
 // Sum up all the local contributions (in SquareSubMatrix) into

--- a/src/SquareSubMatrix2DistMatrix.cc
+++ b/src/SquareSubMatrix2DistMatrix.cc
@@ -20,10 +20,6 @@ template <class T>
 void SquareSubMatrix2DistMatrix::convert(const SquareSubMatrix<T>& src,
     dist_matrix::SparseDistMatrix<T>& dst, const double tol) const
 {
-    const std::vector<int>& gids(src.getGids());
-
-    const short chromatic_number = (short)gids.size();
-
     dst.addData(src, tol);
 }
 

--- a/src/computeHij.cc
+++ b/src/computeHij.cc
@@ -28,8 +28,6 @@
 #include "ProjectedMatricesSparse.h"
 #include "SquareSubMatrix2DistMatrix.h"
 
-static int sparse_distmatrix_nb_partitions = 128;
-
 template <>
 void MGmol<LocGridOrbitals>::addHlocal2matrix(LocGridOrbitals& orbitalsi,
     LocGridOrbitals& orbitalsj, VariableSizeMatrix<sparserow>& mat)

--- a/src/main.cc
+++ b/src/main.cc
@@ -51,6 +51,7 @@ using namespace std;
 #include "Mesh.h"
 #include "PackedCommunicationBuffer.h"
 #include "ReplicatedWorkSpace.h"
+#include "SparseDistMatrix.h"
 #include "magma_singleton.h"
 #include "tools.h"
 


### PR DESCRIPTION
* Remove unused include

* Use DistMatrix instead of SparseDistMatrix in
LocGridOrbitals

* Clean up SparseDistMatrix references

* Consolidate some code

* Remove using namespace std

* Modernize some loops