### PR TITLE
fix nullptr issues

### DIFF
--- a/scripts/modules.pel
+++ b/scripts/modules.pel
@@ -1,6 +1,7 @@
-module load cmake/3.14.5
 module load intel/19.0.4 
-module load mkl
 module load hdf5-parallel/1.10.2
 module load boost/1.69.0
+module load mkl/2019.0
+module load cmake/3.14.5
 module load python/3.7.2
+

--- a/src/pb/PEenv.cc
+++ b/src/pb/PEenv.cc
@@ -299,7 +299,7 @@ void PEenv::task2xyz()
 
 void PEenv::setup_my_neighbors()
 {
-    assert(cart_comm_ != nullptr);
+    assert(cart_comm_ != MPI_COMM_NULL);
 
     if (color_ == 0)
     {
@@ -624,7 +624,7 @@ void PEenv::split_comm(const int nx, const int ny, const int nz, const int bias)
     {
         if (comm_active_ != comm_)
         {
-            assert(comm_active_ != nullptr);
+            assert(comm_active_ != MPI_COMM_NULL);
             MPI_Comm_free(&comm_active_);
         }
         for (int i = 0; i < 3; i++)


### PR DESCRIPTION
Use MPI_COMM_NULL instead of nullptr to fix build issues in debug mode on LC systems.