### PR TITLE
add second to the time tag

### DIFF
--- a/src/HDFrestart.cc
+++ b/src/HDFrestart.cc
@@ -161,6 +161,15 @@ void HDFrestart::addDateToFilename()
         filename_.append("0");
     }
     filename_.append(extension);
+
+    // seconds
+    filename_.append("_");
+    extension = std::to_string(tt1->tm_sec);
+    if (tt1->tm_sec < 10)
+    {
+        filename_.append("0");
+    }
+    filename_.append(extension);
     MGmol_MPI& mmpi = *(MGmol_MPI::instance());
     // make sure all the PEs use the same filename
     std::vector<char> name_buffer(filename_.begin(), filename_.end());


### PR DESCRIPTION
usually hdfrestart adds the time tag to the file, so that the restart files are not overwritten within a simulation. This time tag only includes down to minutes, so the restart file is overwritten if the saving happens within the same minute. This does not happen most of time, only for small-scale simulation (carbyne example). Now the time tag also includes the second.