### PR TITLE
Use unique restart filenames in test HDF5single

### DIFF
--- a/tests/HDF5single/md.cfg
+++ b/tests/HDF5single/md.cfg
@@ -25,10 +25,10 @@ max_steps=24
 atol=1.e-8
 [Restart]
 input_level=4
-input_filename=WF
+input_filename=wf.h5
 input_type=single_file
 output_level=4
-output_filename=WF_MD
+output_filename=wf_md.h5
 output_type=single_file
 [Coloring]
 scope=global

--- a/tests/HDF5single/mgmol.cfg
+++ b/tests/HDF5single/mgmol.cfg
@@ -25,7 +25,7 @@ initial_type=Random
 initial_width=1.5
 [Restart]
 output_level=4
-output_filename=WF
+output_filename=wf.h5
 output_type=single_file
 [Coloring]
 scope=global

--- a/tests/HDF5single/test.py
+++ b/tests/HDF5single/test.py
@@ -47,7 +47,7 @@ print("Run command: {}".format(command))
 output = subprocess.check_output(command,shell=True)
 lines=output.split(b'\n')
 
-os.remove('WF')
+os.remove('wf.h5')
 
 print("Check energy conservation...")
 tol = 1.e-4
@@ -70,6 +70,8 @@ for line in lines:
 if count<4:
   print("ERROR needs 4 energy values for checking conservation!")
   sys.exit(1)
+
+os.remove('wf_md.h5')
 
 print("Test SUCCESSFUL!")
 sys.exit(0)


### PR DESCRIPTION
Previous names were leading to failure depending if directory with same name existed already