### PR TITLE
Fixing DM tolerance

### DIFF
--- a/src/Control.cc
+++ b/src/Control.cc
@@ -224,7 +224,7 @@ void Control::print(std::ostream& os)
        << conv_tol << std::endl;
     os << std::fixed;
     os << " Density matrix mixing = " << dm_mix << std::endl;
-    os << std::setprecision(4) << std::scientific << << " Density matrix tol = " << dm_tol << std::endl;
+    os << std::setprecision(4) << std::scientific << " Density matrix tol = " << dm_tol << std::endl;
     if (DMEigensolver() == DMEigensolverType::Eigensolver)
     {
         os << " Density matrix computation algorithm = "

--- a/src/Control.cc
+++ b/src/Control.cc
@@ -224,7 +224,7 @@ void Control::print(std::ostream& os)
        << conv_tol << std::endl;
     os << std::fixed;
     os << " Density matrix mixing = " << dm_mix << std::endl;
-    os << " Density matrix tol = " << dm_tol << std::endl;
+    os << std::setprecision(4) << std::scientific << << " Density matrix tol = " << dm_tol << std::endl;
     if (DMEigensolver() == DMEigensolverType::Eigensolver)
     {
         os << " Density matrix computation algorithm = "
@@ -1742,8 +1742,6 @@ void Control::setOptions(const boost::program_options::variables_map& vm)
         }
         else
             dm_algo_ = 2;
-
-        dm_tol = vm["DensityMatrix.tol"].as<float>();
 
         str = vm["DensityMatrix.solver"].as<std::string>();
         if (str.compare("Mixing") == 0) DM_solver_ = 0;

--- a/src/Control.cc
+++ b/src/Control.cc
@@ -224,7 +224,8 @@ void Control::print(std::ostream& os)
        << conv_tol << std::endl;
     os << std::fixed;
     os << " Density matrix mixing = " << dm_mix << std::endl;
-    os << std::setprecision(4) << std::scientific << " Density matrix tol = " << dm_tol << std::endl;
+    os << std::setprecision(4) << std::scientific
+       << " Density matrix tol = " << dm_tol << std::endl;
     if (DMEigensolver() == DMEigensolverType::Eigensolver)
     {
         os << " Density matrix computation algorithm = "

--- a/src/read_config.cc
+++ b/src/read_config.cc
@@ -321,10 +321,7 @@ int read_config(int argc, char** argv, po::variables_map& vm,
             po::value<short>()->default_value(100),
             "Maximum number of iterations for power method "
             "to compute interval for Chebyshev "
-            "approximation of density matrix. ")("DensityMatrix.tol",
-            po::value<float>()->default_value(1.e-7),
-            "tolerance, used in iterative DM computation convergence "
-            "criteria");
+            "approximation of density matrix. ");
 
         po::options_description cmdline_options;
         cmdline_options.add(generic);


### PR DESCRIPTION
- Remove repeated assignment of `dm_tol` in Control
- Fix the print of `Density matrix tol = 0.0` using scientific notation