### PR TITLE
Fix strategy in DataDistribution::computeMaxDataSize()

### DIFF
--- a/src/sparse_linear_algebra/DataDistribution.h
+++ b/src/sparse_linear_algebra/DataDistribution.h
@@ -169,7 +169,9 @@ public:
 
     static void enforceComputeMaxDataSize()
     {
-        count_computeMaxDataSize_ = maxcount_computeMaxDataSize_ - 1;
+        // start with counter at max - 3 so that max is reached after
+        // three calls to computeMaxDataSize(), one for each direction x,y,z
+        count_computeMaxDataSize_ = maxcount_computeMaxDataSize_ - 3;
     }
 
     template <class T>


### PR DESCRIPTION
* was taking the max only in one direction before changing strategy